### PR TITLE
docs: fix path to static source

### DIFF
--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -23,7 +23,7 @@ the following snippet to your HTML page:
 my-web-archive-embed.html
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/replaywebpage/@{{ site.version }}/ui.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/replaywebpage@{{ site.version }}/ui.js"></script>
 <replay-web-page source="s3://webrecorder-builds/warcs/netpreserve-twitter.warc"
 url="https://twitter.com/netpreserve"></replay-web-page>
 ```


### PR DESCRIPTION
In the [docs](https://replayweb.page/docs/embedding) there is a snippet that is like this:
```
<script src="https://cdn.jsdelivr.net/npm/replaywebpage/@1.3.12/ui.js"></script>
```

But that results in an error, if you navigate [there](https://cdn.jsdelivr.net/npm/replaywebpage/@1.3.12/ui.js) with a browser you can see what I mean.

I found that it just has an extra slash.