### PR TITLE
Make `<replay-web-page>` use `display: block` by default to avoid extraneous scoll bars

### DIFF
--- a/src/embed.js
+++ b/src/embed.js
@@ -218,6 +218,7 @@ class Embed extends LitElement
       :host {
         width: 100%;
         height: 100%;
+        display: block;
       }
     `);
   }


### PR DESCRIPTION
### This PR adds `display: block;` to the `<replay-web-page>` element.
The default display mode implies that `<replay-web-page>` does not wrap its contents, and an extraneous scroll bar may therefore show, depending on user preferences.

**See example here on Mac OS after switching to _"Show Scroll Bars: Always"_ in _"Settings > General"_.**
<img width="242" alt="Screen Shot 2022-09-01 at 11 46 04 AM" src="https://user-images.githubusercontent.com/625889/187958765-dff5e290-e1a6-4a80-adc8-eaaabb2bdffd.png">

**Wrapping issue caused by default `display` mode:**
<img width="835" alt="Screen Shot 2022-09-01 at 11 57 22 AM" src="https://user-images.githubusercontent.com/625889/187959723-094b6b15-c21b-49b4-8459-dd4a57b0de43.png">


**After fix:**
<img width="242" alt="Screen Shot 2022-09-01 at 11 46 33 AM" src="https://user-images.githubusercontent.com/625889/187958832-54751b2e-a503-4cda-94b7-95081c5715e9.png">

---

Many thanks to @rebeccacremona who brought this issue to my attention.