### PR TITLE
Adds title back to download button section

### DIFF
--- a/src/embed-receipt.js
+++ b/src/embed-receipt.js
@@ -232,13 +232,14 @@ export class RWPEmbedReceipt extends LitElement
           </div>
           ${sourceUrl ? html`
           <hr class="dropdown-divider">
+          <h2 mt-4">Get A Copy</h2>
+          <p class="mt-2">After downloading, this archive can be loaded and viewed directly in your browser via <a target="_blank" href="https://replayweb.page">replayweb.page</a></p>
           <a href="${sourceUrl}" class="button" @keyup="${clickOnSpacebarPress}">
             <span class="icon is-small">
               <fa-icon size="1.0em" class="has-text-grey" aria-hidden="true" .svg="${fasDownload}"></fa-icon>
             </span>
             <span>Download Archive</span>
           </a>
-          <p class="mt-2">This archive can then be viewed directly in your browser by loading it via <a target="_blank" href="https://replayweb.page">replayweb.page</a></p>
           ` : ""}
           <p class="is-size-7 is-flex is-justify-content-space-between" style="margin-top: 40px">
             <span>

--- a/src/embed-receipt.js
+++ b/src/embed-receipt.js
@@ -232,9 +232,9 @@ export class RWPEmbedReceipt extends LitElement
           </div>
           ${sourceUrl ? html`
           <hr class="dropdown-divider">
-          <h2 mt-4">Get A Copy</h2>
-          <p class="mt-2">After downloading, this archive can be loaded and viewed directly in your browser via <a target="_blank" href="https://replayweb.page">replayweb.page</a></p>
-          <a href="${sourceUrl}" class="button" @keyup="${clickOnSpacebarPress}">
+          <h2 mt-4">Get A Copy!</h2>
+          <p class="mt-2">After downloading, this web archive can be loaded and viewed directly in your browser via <a style="white-space: nowrap;" target="_blank" href="https://replayweb.page">replayweb.page</a>.</p>
+          <a href="${sourceUrl}" class="button mt-4" @keyup="${clickOnSpacebarPress}">
             <span class="icon is-small">
               <fa-icon size="1.0em" class="has-text-grey" aria-hidden="true" .svg="${fasDownload}"></fa-icon>
             </span>


### PR DESCRIPTION
- Adds a header back to the section
- Re-order's copy, now we explain what people are downloading and what they can do with it before the download button so they have a reason to click it
- Adds space between the download button and the text

### Screenshot!
<img width="664" alt="Screen Shot 2022-10-03 at 2 15 01 PM" src="https://user-images.githubusercontent.com/5672810/193649400-6fdc66b1-f020-4aeb-9bac-a3368a9054df.png">