### PR TITLE
Fixes background color in fullscreen mode

### DIFF
--- a/src/coll.js
+++ b/src/coll.js
@@ -412,7 +412,6 @@ class Coll extends LitElement
       flex-direction: column;
       height: 100%;
       min-width: 0px;
-      background-color: white;
     }
 
     .icon {
@@ -477,6 +476,7 @@ class Coll extends LitElement
       flex-direction: column;
       min-height: 0px;
       flex: auto;
+      background-color: white;
     }
 
     #tabContents {

--- a/src/coll.js
+++ b/src/coll.js
@@ -412,6 +412,7 @@ class Coll extends LitElement
       flex-direction: column;
       height: 100%;
       min-width: 0px;
+      background-color: white;
     }
 
     .icon {

--- a/ui.js
+++ b/ui.js
@@ -971,6 +971,7 @@ class se extends oe{}se.directiveName="unsafeSVG",se.resultType=2;const le=ae(se
       flex-direction: column;
       min-height: 0px;
       flex: auto;
+      background-color: white;
     }
 
     #tabContents {


### PR DESCRIPTION
Fixes a small CSS bug which led to the wrong background-color to be picked by `Coll` when  toggling to fullscreen mode while using a dark theme at OS level.

## Before
<img width="1727" alt="Screenshot 2023-03-28 at 11 11 26 AM" src="https://user-images.githubusercontent.com/625889/228284683-39c2a06e-2aae-4a85-94d8-70b0c5ba63cb.png">

## After 
<img width="1727" alt="Screenshot 2023-03-28 at 11 12 56 AM" src="https://user-images.githubusercontent.com/625889/228284685-ce52ef49-b845-4889-8c07-09ae2b38ef1d.png">
