### PR TITLE
Adds the Observer Public Key field to Archive Info

### DIFF
--- a/src/coll-index.js
+++ b/src/coll-index.js
@@ -439,7 +439,7 @@ class CollInfo extends LitElement
   renderDetailed() {
     const coll = this.coll;
 
-    let {numValid, numInvalid, domain, certFingerprint, datapackageHash, software} = this.coll.verify || {};
+    let {numValid, numInvalid, domain, certFingerprint, datapackageHash, publicKey, software} = this.coll.verify || {};
     numValid = numValid || 0;
     numInvalid = numInvalid || 0;
 
@@ -484,6 +484,11 @@ class CollInfo extends LitElement
         <div class="column">
           <p class="minihead">Package Hash</p>
         ${datapackageHash || "Not Available"}
+        </div>
+
+        <div class="column">
+          <p class="minihead">Observer Public Key</p>
+        ${publicKey || "Not Available"}
         </div>
 
         <div class="column">


### PR DESCRIPTION
Parity with archive receipt embed mode!  Closes #193

**Before**
![Screenshot 2023-07-13 at 10-47-09 Archive Info ReplayWeb page](https://github.com/webrecorder/replayweb.page/assets/5672810/c80c014d-7573-49c3-a5a1-7331f48de378)

**After**
![Screenshot 2023-07-13 at 10-45-07 Archive Info ReplayWeb page](https://github.com/webrecorder/replayweb.page/assets/5672810/f6048c6e-b9c9-4b6a-b39b-a43ac908a08c)