### PR TITLE
fixed nginx CORS config

### DIFF
--- a/docs/cors-settings.md
+++ b/docs/cors-settings.md
@@ -106,7 +106,7 @@ location / {
      if ($request_method = 'OPTIONS') {
         add_header 'Access-Control-Allow-Origin' 'https://replayweb.page';
         add_header 'Access-Control-Allow-Methods' 'GET, HEAD, OPTIONS' always;
-        add_header 'Access-Control-Allow-Headers' '*'
+        add_header 'Access-Control-Allow-Headers' '*' ;
         return 204;
      }
 


### PR DESCRIPTION
this missing ";" is needed in nginx, otherwise the config  is invalid, which nginx won't like
Ilya, cheers!