### PR TITLE
Move archive info into dropdown

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -120,8 +120,6 @@ a:focus {
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
   min-width: $body-min-width; // @todo(emma, 2023-11-06) investigate why this is here
-  overflow-x: $body-overflow-x;
-  overflow-y: $body-overflow-y;
   text-rendering: $body-rendering;
   text-size-adjust: 100%;
 
@@ -132,7 +130,6 @@ a:focus {
   line-height: $body-line-height;
 
   box-sizing: border-box;
-  overflow: hidden;
 }
 
 // Make available to screen readers while hiding element visually:

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -119,7 +119,7 @@ a:focus {
   font-size: $body-size;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-  min-width: $body-min-width;
+  min-width: $body-min-width; // @todo(emma, 2023-11-06) investigate why this is here
   overflow-x: $body-overflow-x;
   overflow-y: $body-overflow-y;
   text-rendering: $body-rendering;

--- a/src/appmain.ts
+++ b/src/appmain.ts
@@ -13,8 +13,8 @@ import fasHelp from "@fortawesome/fontawesome-free/svgs/solid/question-circle.sv
 import fasArrowLeft from "@fortawesome/fontawesome-free/svgs/solid/arrow-left.svg";
 import fasArrowRight from "@fortawesome/fontawesome-free/svgs/solid/arrow-right.svg";
 import { SWManager } from "./swmanager";
-import "./coll";
-import "./coll-index";
+import "./item";
+import "./item-index";
 import "./chooser";
 
 // ===========================================================================
@@ -160,7 +160,7 @@ class ReplayWebApp extends LitElement {
         min-width: 0px;
         flex-direction: column;
       }
-      wr-coll {
+      wr-item {
         height: 100%;
       }
       .navbar {
@@ -382,7 +382,7 @@ class ReplayWebApp extends LitElement {
   }
 
   renderColl() {
-    return html` <wr-coll
+    return html` <wr-item
       .loadInfo="${this.loadInfo}"
       sourceUrl="${this.sourceUrl || ""}"
       embed="${this.embed}"
@@ -393,11 +393,11 @@ class ReplayWebApp extends LitElement {
       @update-title=${this.onTitle}
       @coll-loaded=${this.onCollLoaded}
       @about-show=${() => (this.showAbout = true)}
-    ></wr-coll>`;
+    ></wr-item>`;
   }
 
   renderHomeIndex() {
-    return html` <wr-coll-index>
+    return html` <wr-item-index>
       ${!IS_APP
         ? html`
             <p slot="header" class="tagline is-size-5 has-text-centered">
@@ -415,7 +415,7 @@ class ReplayWebApp extends LitElement {
         @did-drop-file="${() => (this.droppedFile = null)}"
         @load-start=${this.onStartLoad}
       ></wr-chooser>
-    </wr-coll-index>`;
+    </wr-item-index>`;
   }
 
   render() {

--- a/src/coll-index.ts
+++ b/src/coll-index.ts
@@ -189,7 +189,6 @@ class CollIndex extends LitElement {
         line-height: 0.4em;
         padding: 6px;
         border-radius: 10px;
-        display: none;
         position: absolute;
       }
       .copy:active {
@@ -346,7 +345,7 @@ class CollIndex extends LitElement {
     `;
   }
 
-  renderCollInfo(coll) {
+  renderCollInfo(coll: Coll) {
     return html`<wr-coll-info .coll=${coll}></wr-coll-info>`;
   }
 
@@ -381,6 +380,7 @@ class CollInfo extends LitElement {
       .column {
         word-break: break-word;
         position: relative;
+        /* font-family: monospace; */
       }
 
       :host {
@@ -405,56 +405,74 @@ class CollInfo extends LitElement {
         height: 100%;
       }
       .column:hover > .copy,
-      .source-text:hover + .copy,
+      .col-content:hover .copy,
       .copy:hover {
-        display: inline;
+        color: inherit;
       }
       .copy {
         color: black;
         margin: 0px;
-        margin: 0;
+        margin: -4px 0 0;
         line-height: 0.4em;
         padding: 6px;
         border-radius: 10px;
-        display: none;
         position: absolute;
       }
       .copy:active {
         background-color: lightgray;
       }
+      .col-content {
+        font-family: monospace;
+        font-size: 14px;
+        color: #1f2937;
+      }
       .minihead {
-        font-size: 10px;
-        font-weight: bold;
+        font-size: 12px;
+        line-height: 16px;
+        margin-bottom: 4px;
       }
     `;
   }
 
-  renderSource(coll) {
+  renderSource() {
+    const coll = this.coll;
     return html`
       <div class="column is-4">
-        <span class="source-text"
-          ><p class="minihead">Source</p>
+        <p class="minihead">Source</p>
+        <div class="col-content">
           ${coll.sourceUrl &&
           (coll.sourceUrl.startsWith("http://") ||
             coll.sourceUrl.startsWith("https://"))
-            ? html` <a href="${coll.sourceUrl}">${coll.sourceUrl}&nbsp;</a>`
-            : html` ${coll.sourceUrl}&nbsp;`}
-        </span>
-
-        <a @click="${(e) => this.onCopy(e, coll.sourceUrl)}" class="copy">
-          <fa-icon .svg="${fasCopy}"></fa-icon>
-        </a>
-        ${coll.sourceUrl && coll.sourceUrl.startsWith("googledrive://")
-          ? html` <p><i>(${coll.filename})</i></p>`
-          : ""}
+            ? html` <a href="${coll.sourceUrl}">${coll.sourceUrl}</a> `
+            : html` ${coll.sourceUrl}`}
+          ${coll.sourceUrl && coll.sourceUrl.startsWith("googledrive://")
+            ? html` <i>(${coll.filename})</i>`
+            : ""}
+          <a @click="${(e) => this.onCopy(e, coll.sourceUrl)}" class="copy">
+            <fa-icon .svg="${fasCopy}"></fa-icon>
+          </a>
+        </div>
+      </div>
+      <div class="column">
+        <p class="minihead">Collection id</p>
+        <div class="col-content">
+          ${coll.coll}
+          <a @click="${(e) => this.onCopy(e, coll.coll)}" class="copy">
+            <fa-icon .svg="${fasCopy}"></fa-icon>
+          </a>
+        </div>
       </div>
       <div class="column is-2">
         <p class="minihead">Date Loaded</p>
-        ${coll.ctime ? new Date(coll.ctime).toLocaleString() : ""}
+        <div class="col-content">
+          ${coll.ctime ? new Date(coll.ctime).toLocaleString() : ""}
+        </div>
       </div>
       <div class="column is-2">
         <p class="minihead">Total Size</p>
-        ${prettyBytes(Number(coll.totalSize || coll.size || 0))}
+        <div class="col-content">
+          ${prettyBytes(Number(coll.totalSize || coll.size || 0))}
+        </div>
       </div>
     `;
   }
@@ -470,7 +488,7 @@ class CollInfo extends LitElement {
           >
         </span>
       </div>
-      ${this.renderSource(coll)}
+      ${this.renderSource()}
     </div>`;
   }
 
@@ -494,24 +512,16 @@ class CollInfo extends LitElement {
       : "";
 
     return html` <div class="columns">
-      <div class="column col-title is-4">
-        <span class="subtitle has-text-weight-bold">
-          ${coll.name || coll.title || coll.filename}
-        </span>
-      </div>
-      ${coll.desc
-        ? html` <div class="column">
-            <p class="minihead">Description</p>
-            ${coll.desc}
-          </div>`
-        : html``}
-      ${coll.description
+      ${coll.name || coll.title
         ? html`<div class="column">
-            <p class="minihead">Description</p>
-            ${coll.description}
+            <p class="minihead">Title</p>
+            <div class="col-content">${coll.name || coll.title}</div>
           </div>`
-        : html``}
-      <!--  Only show filename if coll.resources doesn't exist -->
+        : ""}
+      <div class="column">
+        <p class="minihead">Filename</p>
+        <div class="col-content">${coll.filename}</div>
+      </div>
       ${coll.resources
         ? html`<div class="column">
             <p class="minihead">Files</p>
@@ -525,61 +535,70 @@ class CollInfo extends LitElement {
               )}
             </ol>
           </div>`
-        : html`<div class="column">
-            <p class="minihead">Filename</p>
-            ${coll.filename}
-          </div>`}
-      ${this.renderSource(coll)}
+        : ""}
+      ${this.renderSource()}
       ${domain
         ? html`
             <div class="column">
               <p class="minihead">Observed By</p>
-              <p>${domain}</p>
-              ${certFingerprintUrl
-                ? html`<span
-                    ><a target="_blank" href="${certFingerprintUrl}"
-                      >View Certificate</a
-                    ></span
-                  >`
-                : ""}
+              <span class="col-content">
+                <p>${domain}</p>
+                ${certFingerprintUrl
+                  ? html`<span
+                      ><a target="_blank" href="${certFingerprintUrl}"
+                        >View Certificate</a
+                      ></span
+                    >`
+                  : ""}
+              </span>
             </div>
           `
         : software
         ? html`
             <div class="column">
               <p class="minihead">Created With</p>
-              ${software || "Unknown"}
+              <div class="col-content">${software || "Unknown"}</div>
             </div>
           `
         : ""}
 
       <div class="column">
         <p class="minihead">Validation</p>
-        ${numValid > 0 || numInvalid > 0
-          ? html` <p>
-              ${numValid} hashes
-              verified${numInvalid ? html`, ${numInvalid} invalid` : ""}
-            </p>`
-          : html` Not Available`}
+        <div class="col-content">
+          ${numValid > 0 || numInvalid > 0
+            ? html` <p>
+                ${numValid} hashes
+                verified${numInvalid ? html`, ${numInvalid} invalid` : ""}
+              </p>`
+            : html` Not Available`}
+        </div>
       </div>
 
       <div class="column">
         <p class="minihead">Package Hash</p>
-        ${datapackageHash || "Not Available"}
+        <div class="col-content">
+          ${datapackageHash || "Not Available"}
+          <a @click="${(e) => this.onCopy(e, datapackageHash)}" class="copy">
+            <fa-icon .svg="${fasCopy}"></fa-icon>
+          </a>
+        </div>
       </div>
 
       <div class="column">
         <p class="minihead">Observer Public Key</p>
-        ${publicKey || "Not Available"}
+        <div class="col-content">
+          ${publicKey || "Not Available"}
+          <a @click="${(e) => this.onCopy(e, publicKey)}" class="copy">
+            <fa-icon .svg="${fasCopy}"></fa-icon>
+          </a>
+        </div>
       </div>
 
       <div class="column">
         <p class="minihead">Loading Mode</p>
-        ${coll.onDemand ? "Download On-Demand" : "Fully Local"}
-      </div>
-      <div class="column">
-        <p class="minihead">Collection id</p>
-        ${coll.coll}
+        <div class="col-content">
+          ${coll.onDemand ? "Download On-Demand" : "Fully Local"}
+        </div>
       </div>
     </div>`;
   }
@@ -588,10 +607,10 @@ class CollInfo extends LitElement {
     return this.detailed ? this.renderDetailed() : this.renderSummaryView();
   }
 
-  onCopy(event, sourceUrl) {
+  onCopy(event: Event, text: string | undefined) {
     event.preventDefault();
     event.stopPropagation();
-    navigator.clipboard.writeText(sourceUrl);
+    if (text) navigator.clipboard.writeText(text);
     return false;
   }
 

--- a/src/coll-index.ts
+++ b/src/coll-index.ts
@@ -380,7 +380,6 @@ class CollInfo extends LitElement {
       .column {
         word-break: break-word;
         position: relative;
-        /* font-family: monospace; */
       }
 
       :host {

--- a/src/coll.ts
+++ b/src/coll.ts
@@ -1,10 +1,9 @@
 import { LitElement, html, css } from "lit";
-import { property, state } from "lit/decorators.js";
+import { property } from "lit/decorators.js";
 import { ref, createRef, type Ref } from "lit/directives/ref.js";
 import type {
   SlDialog,
   SlDropdown,
-  SlMenu,
   SlSelectEvent,
 } from "@shoelace-style/shoelace";
 import "@shoelace-style/shoelace/dist/components/alert/alert.js";

--- a/src/coll.ts
+++ b/src/coll.ts
@@ -1,10 +1,14 @@
 import { LitElement, html, css } from "lit";
 import { property, state } from "lit/decorators.js";
+import { ref, createRef, type Ref } from "lit/directives/ref.js";
 import type {
+  SlDialog,
   SlDropdown,
   SlMenu,
   SlSelectEvent,
 } from "@shoelace-style/shoelace";
+import "@shoelace-style/shoelace/dist/components/dialog/dialog.js";
+import "@shoelace-style/shoelace/dist/components/button/button.js";
 import {
   wrapCss,
   rwpLogo,
@@ -80,7 +84,7 @@ class Coll extends LitElement {
 
   @property({ type: Object, attribute: false })
   tabData: {
-    view?: string;
+    view?: "story" | "pages" | "resources";
     url?: string;
     ts?: string;
     multiTs?: string[];
@@ -148,6 +152,8 @@ class Coll extends LitElement {
   private _autoUpdater: null | Promise<void> = null;
 
   private observer?: IntersectionObserver;
+
+  private archiveInfoDialog: Ref<SlDialog> = createRef();
 
   private readonly tabNames = ["pages", "story", "resources", "info"];
   private readonly tabLabels = {
@@ -876,6 +882,15 @@ class Coll extends LitElement {
     } else if (this.collInfo) {
       return html`
         ${this.renderLocationBar()} ${this.renderVerifyInfo()}
+        <sl-dialog label="Archive Info" ${ref(this.archiveInfoDialog)}>
+          ${this.renderCollInfo()}
+          <sl-button
+            slot="footer"
+            variant="primary"
+            @click="${this.onHideInfoDialog}"
+            >Close</sl-button
+          >
+        </sl-dialog>
         <div id="tabContents">
           <div
             id="contents"
@@ -1018,31 +1033,6 @@ class Coll extends LitElement {
             ></span>
             <span class="tab-label ${isSidebar ? "is-hidden" : ""}" title="URLs"
               >URLs</span
-            >
-          </a>
-        </li>
-
-        <li class="${this.tabData.view === "info" ? "is-active" : ""}">
-          <a
-            @click="${this.onTabClick}"
-            href="#info"
-            class="is-size-6"
-            aria-label="Archive Info"
-            aria-current="${(this.tabData.view === "info"
-              ? "location"
-              : "") as any}"
-          >
-            <span class="icon"
-              ><fa-icon
-                .svg="${fasInfoIcon}"
-                aria-hidden="true"
-                title="Archive Info"
-              ></fa-icon
-            ></span>
-            <span
-              class="tab-label ${isSidebar ? "is-hidden" : ""}"
-              title="Archive Info"
-              >Info</span
             >
           </a>
         </li>
@@ -1379,6 +1369,21 @@ class Coll extends LitElement {
                         <span class="menu-head">Capture Date</span>${dateStr}
                       </div>`
                   : ""}
+                <a
+                  href="#"
+                  role="button"
+                  class="dropdown-item"
+                  @click="${this.onShowInfoDialog}"
+                >
+                  <span class="icon is-small">
+                    <fa-icon
+                      class="has-text-grey"
+                      aria-hidden="true"
+                      .svg="${fasInfoIcon}"
+                    ></fa-icon>
+                  </span>
+                  <span>Archive Info</span>
+                </a>
                 <hr class="dropdown-divider" />
                 <a
                   href="#"
@@ -1500,10 +1505,8 @@ class Coll extends LitElement {
     const isStory = this.hasStory && this.tabData.view === "story";
     const isPages = this.tabData.view === "pages";
     const isResources = this.tabData.view === "resources";
-    const isInfo = this.tabData.view === "info";
 
     return html`
-      ${isInfo ? this.renderCollInfo() : html``}
       ${isStory
         ? html` <wr-coll-story
             .collInfo="${this.collInfo || {}}"
@@ -1795,6 +1798,12 @@ class Coll extends LitElement {
 
   onAbout() {
     this.dispatchEvent(new CustomEvent("about-show"));
+  }
+  onShowInfoDialog() {
+    this.archiveInfoDialog.value?.show();
+  }
+  onHideInfoDialog() {
+    this.archiveInfoDialog.value?.hide();
   }
 }
 

--- a/src/coll.ts
+++ b/src/coll.ts
@@ -7,8 +7,9 @@ import type {
   SlMenu,
   SlSelectEvent,
 } from "@shoelace-style/shoelace";
-import "@shoelace-style/shoelace/dist/components/dialog/dialog.js";
+import "@shoelace-style/shoelace/dist/components/alert/alert.js";
 import "@shoelace-style/shoelace/dist/components/button/button.js";
+import "@shoelace-style/shoelace/dist/components/dialog/dialog.js";
 import {
   wrapCss,
   rwpLogo,
@@ -782,17 +783,7 @@ class Coll extends LitElement {
         width: 100%;
       }
 
-      .info-bg {
-        background-color: whitesmoke;
-        width: 100%;
-        height: 100%;
-        display: flex;
-        overflow: auto;
-      }
-
       .is-list {
-        margin: 1em;
-        background-color: whitesmoke;
         height: fit-content;
       }
 
@@ -1485,16 +1476,19 @@ class Coll extends LitElement {
   }
 
   renderCollInfo() {
-    if (!this.collInfo) return;
-    return html` <div class="info-bg">
-      <wr-coll-info
-        class="is-list"
-        .coll="${this.collInfo}"
-        ?detailed="${true}"
-        ?canDelete="${!this.embed}"
-        @coll-purge="${this.onPurgeCache}"
-      ></wr-coll-info>
-    </div>`;
+    if (!this.collInfo)
+      return html`<sl-alert open variant="warning">
+        <sl-icon slot="icon" name="exclamation-triangle"></sl-icon>
+        <strong>Archive info is not available</strong><br />
+        Please reload and try again.
+      </sl-alert>`;
+    return html`<wr-coll-info
+      class="is-list"
+      .coll="${this.collInfo}"
+      ?detailed="${true}"
+      ?canDelete="${!this.embed}"
+      @coll-purge="${this.onPurgeCache}"
+    ></wr-coll-info>`;
   }
 
   renderExtraToolbar(/*isDropdown = false*/) {

--- a/src/components/labeled-field.ts
+++ b/src/components/labeled-field.ts
@@ -1,0 +1,104 @@
+import { LitElement, css, html, nothing } from "lit";
+import { property } from "lit/decorators.js";
+
+import fasCopy from "@fortawesome/fontawesome-free/svgs/regular/copy.svg";
+import "./../misc";
+import { wrapCss } from "./../misc";
+
+class LabeledField extends LitElement {
+  @property({
+    converter: (value) => {
+      if (value === "") return true;
+      if (value == null) return false;
+      return value;
+    },
+  })
+  copy?: boolean | string = false;
+
+  @property({ type: String })
+  label?: string;
+
+  @property({ type: String })
+  class?: string;
+
+  static get styles() {
+    return wrapCss(LabeledField.compStyles);
+  }
+
+  static get compStyles() {
+    return css`
+      :host {
+        word-break: break-word;
+        position: relative;
+        min-width: unset; /* @todo(emma, 2023-11-06) see about removing this, if the min-width set on all web components is unnecessary */
+      }
+
+      .copy {
+        color: black;
+        margin: 0px;
+        margin: -4px 0 0;
+        line-height: 0.4em;
+        padding: 6px;
+        border-radius: 10px;
+        position: absolute;
+        appearance: none;
+        background: none;
+        border: none;
+        cursor: pointer;
+      }
+      .copy:active {
+        background-color: lightgray;
+      }
+      .col-content {
+        font-family: monospace;
+        font-size: 14px;
+        color: #1f2937;
+      }
+      .minihead {
+        font-size: 12px;
+        line-height: 16px;
+        margin-bottom: 4px;
+      }
+    `;
+  }
+
+  private get _copyableContent() {
+    const slot = this.shadowRoot?.querySelector("slot");
+    const content =
+      typeof this.copy === "string"
+        ? this.copy
+        : slot
+            ?.assignedNodes({ flatten: true })
+            .map((node) => node.textContent?.replace(/^\s+|\s+$/g, " "))
+            .join("")
+            .trim();
+    return content;
+  }
+
+  render() {
+    console.log(this.label, "copy", this.copy);
+    return html`${this.label
+        ? html`<p class="minihead">${this.label}</p>`
+        : nothing}
+      <div class="col-content">
+        <slot></slot>
+        ${this.copy
+          ? html`<button @click="${this.onCopy}" class="copy">
+              <fa-icon .svg="${fasCopy}"></fa-icon>
+            </button>`
+          : ""}
+      </div>`;
+  }
+
+  onCopy(event: Event) {
+    event.preventDefault();
+    event.stopPropagation();
+    const text = this._copyableContent;
+    if (text) navigator.clipboard.writeText(text);
+    return false;
+  }
+}
+
+customElements.define("wr-labeled-field", LabeledField);
+
+export { LabeledField };

--- a/src/components/labeled-field.ts
+++ b/src/components/labeled-field.ts
@@ -1,19 +1,13 @@
 import { LitElement, css, html, nothing } from "lit";
-import { property } from "lit/decorators.js";
+import { customElement, property } from "lit/decorators.js";
 
-import fasCopy from "@fortawesome/fontawesome-free/svgs/regular/copy.svg";
-import "./../misc";
 import { wrapCss } from "./../misc";
+import "@shoelace-style/shoelace/dist/components/copy-button/copy-button.js";
 
+@customElement("wr-labeled-field")
 class LabeledField extends LitElement {
-  @property({
-    converter: (value) => {
-      if (value === "") return true;
-      if (value == null) return false;
-      return value;
-    },
-  })
-  copy?: boolean | string = false;
+  @property({ type: String })
+  copy?: string;
 
   @property({ type: String })
   label?: string;
@@ -28,31 +22,16 @@ class LabeledField extends LitElement {
   static get compStyles() {
     return css`
       :host {
-        word-break: break-word;
-        position: relative;
         min-width: unset; /* @todo(emma, 2023-11-06) see about removing this, if the min-width set on all web components is unnecessary */
       }
 
-      .copy {
-        color: black;
-        margin: 0px;
-        margin: -4px 0 0;
-        line-height: 0.4em;
-        padding: 6px;
-        border-radius: 10px;
-        position: absolute;
-        appearance: none;
-        background: none;
-        border: none;
-        cursor: pointer;
-      }
-      .copy:active {
-        background-color: lightgray;
-      }
+      /* @todo(emma, 2023-11-06) add option for monospace treatment, rather than making everything mono. this could also be a class on the host element? */
       .col-content {
         font-family: monospace;
         font-size: 14px;
         color: #1f2937;
+        display: flex;
+        align-items: center;
       }
       .minihead {
         font-size: 12px;
@@ -62,43 +41,17 @@ class LabeledField extends LitElement {
     `;
   }
 
-  private get _copyableContent() {
-    const slot = this.shadowRoot?.querySelector("slot");
-    const content =
-      typeof this.copy === "string"
-        ? this.copy
-        : slot
-            ?.assignedNodes({ flatten: true })
-            .map((node) => node.textContent?.replace(/^\s+|\s+$/g, " "))
-            .join("")
-            .trim();
-    return content;
-  }
-
   render() {
-    console.log(this.label, "copy", this.copy);
     return html`${this.label
         ? html`<p class="minihead">${this.label}</p>`
         : nothing}
       <div class="col-content">
         <slot></slot>
         ${this.copy
-          ? html`<button @click="${this.onCopy}" class="copy">
-              <fa-icon .svg="${fasCopy}"></fa-icon>
-            </button>`
-          : ""}
+          ? html` <sl-copy-button .value=${this.copy || ""}></sl-copy-button>`
+          : nothing}
       </div>`;
   }
-
-  onCopy(event: Event) {
-    event.preventDefault();
-    event.stopPropagation();
-    const text = this._copyableContent;
-    if (text) navigator.clipboard.writeText(text);
-    return false;
-  }
 }
-
-customElements.define("wr-labeled-field", LabeledField);
 
 export { LabeledField };

--- a/src/item-index.ts
+++ b/src/item-index.ts
@@ -1,23 +1,20 @@
 import { LitElement, html, css } from "lit";
 import { property, state } from "lit/decorators.js";
 import { wrapCss, apiPrefix } from "./misc";
-import { map } from "lit/directives/map.js";
-
-import prettyBytes from "pretty-bytes";
-
-import fasCopy from "@fortawesome/fontawesome-free/svgs/regular/copy.svg";
 
 import fasArrowUp from "@fortawesome/fontawesome-free/svgs/solid/angle-double-up.svg";
 import fasArrowDown from "@fortawesome/fontawesome-free/svgs/solid/angle-double-down.svg";
 
 import fasSearch from "@fortawesome/fontawesome-free/svgs/solid/search.svg";
 
-import type { Coll } from "./types";
+import type { Item } from "./types";
+
+import "./item-info";
 
 // ===========================================================================
-class CollIndex extends LitElement {
+class ItemIndex extends LitElement {
   @property({ type: Array })
-  colls: Coll[] = [];
+  colls: Item[] = [];
 
   @property({ type: String })
   query = "";
@@ -142,7 +139,7 @@ class CollIndex extends LitElement {
   }
 
   static get styles() {
-    return wrapCss(CollIndex.compStyles);
+    return wrapCss(ItemIndex.compStyles);
   }
 
   static get compStyles() {
@@ -345,8 +342,8 @@ class CollIndex extends LitElement {
     `;
   }
 
-  renderCollInfo(coll: Coll) {
-    return html`<wr-coll-info .coll=${coll}></wr-coll-info>`;
+  renderCollInfo(item: Item) {
+    return html`<wr-item-info .item=${item}></wr-item-info>`;
   }
 
   renderEmpty() {
@@ -357,267 +354,6 @@ class CollIndex extends LitElement {
   }
 }
 
-// ===========================================================================
-class CollInfo extends LitElement {
-  @property({ type: Object })
-  coll!: Coll | Record<string, never>;
+customElements.define("wr-item-index", ItemIndex);
 
-  @property({ type: Boolean })
-  detailed = false;
-
-  @property({ type: Boolean })
-  canDelete = false;
-
-  static get styles() {
-    return wrapCss(CollInfo.compStyles);
-  }
-
-  static get compStyles() {
-    return css`
-      .columns {
-        width: 100%;
-      }
-      .column {
-        word-break: break-word;
-        position: relative;
-      }
-
-      :host {
-        width: 100%;
-        height: 100%;
-        min-width: 0px;
-      }
-
-      :host(.is-list) .columns {
-        display: flex !important;
-        flex-direction: column;
-      }
-
-      :host(.is-list) .column {
-        width: 100% !important;
-      }
-
-      .col-title:hover {
-      }
-      .col-title a {
-        display: block;
-        height: 100%;
-      }
-      .column:hover > .copy,
-      .col-content:hover .copy,
-      .copy:hover {
-        color: inherit;
-      }
-      .copy {
-        color: black;
-        margin: 0px;
-        margin: -4px 0 0;
-        line-height: 0.4em;
-        padding: 6px;
-        border-radius: 10px;
-        position: absolute;
-      }
-      .copy:active {
-        background-color: lightgray;
-      }
-      .col-content {
-        font-family: monospace;
-        font-size: 14px;
-        color: #1f2937;
-      }
-      .minihead {
-        font-size: 12px;
-        line-height: 16px;
-        margin-bottom: 4px;
-      }
-    `;
-  }
-
-  renderSource() {
-    const coll = this.coll;
-    return html`
-      <div class="column is-4">
-        <p class="minihead">Source</p>
-        <div class="col-content">
-          ${coll.sourceUrl &&
-          (coll.sourceUrl.startsWith("http://") ||
-            coll.sourceUrl.startsWith("https://"))
-            ? html` <a href="${coll.sourceUrl}">${coll.sourceUrl}</a> `
-            : html` ${coll.sourceUrl}`}
-          ${coll.sourceUrl && coll.sourceUrl.startsWith("googledrive://")
-            ? html` <i>(${coll.filename})</i>`
-            : ""}
-          <a @click="${(e) => this.onCopy(e, coll.sourceUrl)}" class="copy">
-            <fa-icon .svg="${fasCopy}"></fa-icon>
-          </a>
-        </div>
-      </div>
-      <div class="column">
-        <p class="minihead">Collection id</p>
-        <div class="col-content">
-          ${coll.coll}
-          <a @click="${(e) => this.onCopy(e, coll.coll)}" class="copy">
-            <fa-icon .svg="${fasCopy}"></fa-icon>
-          </a>
-        </div>
-      </div>
-      <div class="column is-2">
-        <p class="minihead">Date Loaded</p>
-        <div class="col-content">
-          ${coll.ctime ? new Date(coll.ctime).toLocaleString() : ""}
-        </div>
-      </div>
-      <div class="column is-2">
-        <p class="minihead">Total Size</p>
-        <div class="col-content">
-          ${prettyBytes(Number(coll.totalSize || coll.size || 0))}
-        </div>
-      </div>
-    `;
-  }
-
-  renderSummaryView() {
-    const coll = this.coll;
-
-    return html` <div class="columns">
-      <div class="column col-title is-4">
-        <span class="subtitle has-text-weight-bold">
-          <a href="?source=${encodeURIComponent(coll.sourceUrl)}"
-            >${coll.name || coll.title || coll.filename}</a
-          >
-        </span>
-      </div>
-      ${this.renderSource()}
-    </div>`;
-  }
-
-  renderDetailed() {
-    const coll = this.coll;
-
-    const {
-      numValid = 0,
-      numInvalid = 0,
-      domain,
-      certFingerprint,
-      datapackageHash,
-      publicKey,
-      software,
-    } = this.coll.verify || {};
-
-    const certFingerprintUrl = certFingerprint
-      ? `https://crt.sh/?q=${certFingerprint}`
-      : "";
-
-    return html` <div class="columns">
-      ${coll.name || coll.title
-        ? html`<div class="column">
-            <p class="minihead">Title</p>
-            <div class="col-content">${coll.name || coll.title}</div>
-          </div>`
-        : ""}
-      <div class="column">
-        <p class="minihead">Filename</p>
-        <div class="col-content">${coll.filename}</div>
-      </div>
-      ${coll.resources
-        ? html`<div class="column">
-            <p class="minihead">Files</p>
-            <ol style="padding: revert">
-              ${map(
-                coll.resources,
-                (resource: any) =>
-                  html`<li>
-                    <a href="${resource.path}">${resource.name + "\n"}</a>
-                  </li>`,
-              )}
-            </ol>
-          </div>`
-        : ""}
-      ${this.renderSource()}
-      ${domain
-        ? html`
-            <div class="column">
-              <p class="minihead">Observed By</p>
-              <span class="col-content">
-                <p>${domain}</p>
-                ${certFingerprintUrl
-                  ? html`<span
-                      ><a target="_blank" href="${certFingerprintUrl}"
-                        >View Certificate</a
-                      ></span
-                    >`
-                  : ""}
-              </span>
-            </div>
-          `
-        : software
-        ? html`
-            <div class="column">
-              <p class="minihead">Created With</p>
-              <div class="col-content">${software || "Unknown"}</div>
-            </div>
-          `
-        : ""}
-
-      <div class="column">
-        <p class="minihead">Validation</p>
-        <div class="col-content">
-          ${numValid > 0 || numInvalid > 0
-            ? html` <p>
-                ${numValid} hashes
-                verified${numInvalid ? html`, ${numInvalid} invalid` : ""}
-              </p>`
-            : html` Not Available`}
-        </div>
-      </div>
-
-      <div class="column">
-        <p class="minihead">Package Hash</p>
-        <div class="col-content">
-          ${datapackageHash || "Not Available"}
-          <a @click="${(e) => this.onCopy(e, datapackageHash)}" class="copy">
-            <fa-icon .svg="${fasCopy}"></fa-icon>
-          </a>
-        </div>
-      </div>
-
-      <div class="column">
-        <p class="minihead">Observer Public Key</p>
-        <div class="col-content">
-          ${publicKey || "Not Available"}
-          <a @click="${(e) => this.onCopy(e, publicKey)}" class="copy">
-            <fa-icon .svg="${fasCopy}"></fa-icon>
-          </a>
-        </div>
-      </div>
-
-      <div class="column">
-        <p class="minihead">Loading Mode</p>
-        <div class="col-content">
-          ${coll.onDemand ? "Download On-Demand" : "Fully Local"}
-        </div>
-      </div>
-    </div>`;
-  }
-
-  render() {
-    return this.detailed ? this.renderDetailed() : this.renderSummaryView();
-  }
-
-  onCopy(event: Event, text: string | undefined) {
-    event.preventDefault();
-    event.stopPropagation();
-    if (text) navigator.clipboard.writeText(text);
-    return false;
-  }
-
-  onPurge(reload) {
-    const detail = { reload };
-    this.dispatchEvent(new CustomEvent("coll-purge", { detail }));
-  }
-}
-
-customElements.define("wr-coll-info", CollInfo);
-customElements.define("wr-coll-index", CollIndex);
-
-export { CollIndex, CollInfo };
+export { ItemIndex as CollIndex };

--- a/src/item-info.ts
+++ b/src/item-info.ts
@@ -102,7 +102,11 @@ class ItemInfo extends LitElement {
           : nothing}
       </wr-labeled-field>
       ${showItemID
-        ? html`<wr-labeled-field label="Archived Item ID" copy class="column">
+        ? html`<wr-labeled-field
+            label="Archived Item ID"
+            .copy=${item.coll}
+            class="column"
+          >
             ${item.coll || "No ID"}
           </wr-labeled-field>`
         : nothing}

--- a/src/item-info.ts
+++ b/src/item-info.ts
@@ -1,0 +1,271 @@
+import { LitElement, html, css } from "lit";
+import { property } from "lit/decorators.js";
+import { wrapCss } from "./misc";
+import { map } from "lit/directives/map.js";
+import prettyBytes from "pretty-bytes";
+import fasCopy from "@fortawesome/fontawesome-free/svgs/regular/copy.svg";
+import type { Item } from "./types";
+
+// ===========================================================================
+class ItemInfo extends LitElement {
+  @property({ type: Object })
+  item!: Item | Record<string, never>;
+
+  @property({ type: Boolean })
+  detailed = false;
+
+  @property({ type: Boolean })
+  canDelete = false;
+
+  static get styles() {
+    return wrapCss(ItemInfo.compStyles);
+  }
+
+  static get compStyles() {
+    return css`
+      .columns {
+        width: 100%;
+      }
+      .column {
+        word-break: break-word;
+        position: relative;
+      }
+
+      :host {
+        width: 100%;
+        height: 100%;
+        min-width: 0px;
+      }
+
+      :host(.is-list) .columns {
+        display: flex !important;
+        flex-direction: column;
+      }
+
+      :host(.is-list) .column {
+        width: 100% !important;
+      }
+
+      .col-title:hover {
+      }
+      .col-title a {
+        display: block;
+        height: 100%;
+      }
+      .column:hover > .copy,
+      .col-content:hover .copy,
+      .copy:hover {
+        color: inherit;
+      }
+      .copy {
+        color: black;
+        margin: 0px;
+        margin: -4px 0 0;
+        line-height: 0.4em;
+        padding: 6px;
+        border-radius: 10px;
+        position: absolute;
+      }
+      .copy:active {
+        background-color: lightgray;
+      }
+      .col-content {
+        font-family: monospace;
+        font-size: 14px;
+        color: #1f2937;
+      }
+      .minihead {
+        font-size: 12px;
+        line-height: 16px;
+        margin-bottom: 4px;
+      }
+    `;
+  }
+
+  renderSource() {
+    const item = this.item;
+    return html`
+      <div class="column is-4">
+        <p class="minihead">Source</p>
+        <div class="col-content">
+          ${item.sourceUrl &&
+          (item.sourceUrl.startsWith("http://") ||
+            item.sourceUrl.startsWith("https://"))
+            ? html` <a href="${item.sourceUrl}">${item.sourceUrl}</a> `
+            : html` ${item.sourceUrl}`}
+          ${item.sourceUrl && item.sourceUrl.startsWith("googledrive://")
+            ? html` <i>(${item.filename})</i>`
+            : ""}
+          <a @click="${(e) => this.onCopy(e, item.sourceUrl)}" class="copy">
+            <fa-icon .svg="${fasCopy}"></fa-icon>
+          </a>
+        </div>
+      </div>
+      <div class="column">
+        <p class="minihead">Archived Item ID</p>
+        <div class="col-content">
+          ${item.coll}
+          <a @click="${(e) => this.onCopy(e, item.coll)}" class="copy">
+            <fa-icon .svg="${fasCopy}"></fa-icon>
+          </a>
+        </div>
+      </div>
+      <div class="column is-2">
+        <p class="minihead">Date Loaded</p>
+        <div class="col-content">
+          ${item.ctime ? new Date(item.ctime).toLocaleString() : ""}
+        </div>
+      </div>
+      <div class="column is-2">
+        <p class="minihead">Total Size</p>
+        <div class="col-content">
+          ${prettyBytes(Number(item.totalSize || item.size || 0))}
+        </div>
+      </div>
+    `;
+  }
+
+  renderSummaryView() {
+    const item = this.item;
+
+    return html` <div class="columns">
+      <div class="column col-title is-4">
+        <span class="subtitle has-text-weight-bold">
+          <a href="?source=${encodeURIComponent(item.sourceUrl)}"
+            >${item.name || item.title || item.filename}</a
+          >
+        </span>
+      </div>
+      ${this.renderSource()}
+    </div>`;
+  }
+
+  renderDetailed() {
+    const item = this.item;
+
+    const {
+      numValid = 0,
+      numInvalid = 0,
+      domain,
+      certFingerprint,
+      datapackageHash,
+      publicKey,
+      software,
+    } = this.item.verify || {};
+
+    const certFingerprintUrl = certFingerprint
+      ? `https://crt.sh/?q=${certFingerprint}`
+      : "";
+
+    return html` <div class="columns">
+      ${item.name || item.title
+        ? html`<div class="column">
+            <p class="minihead">Title</p>
+            <div class="col-content">${item.name || item.title}</div>
+          </div>`
+        : ""}
+      <div class="column">
+        <p class="minihead">Filename</p>
+        <div class="col-content">${item.filename}</div>
+      </div>
+      ${item.resources
+        ? html`<div class="column">
+            <p class="minihead">Files</p>
+            <ol style="padding: revert">
+              ${map(
+                item.resources,
+                (resource: any) =>
+                  html`<li>
+                    <a href="${resource.path}">${resource.name + "\n"}</a>
+                  </li>`,
+              )}
+            </ol>
+          </div>`
+        : ""}
+      ${this.renderSource()}
+      ${domain
+        ? html`
+            <div class="column">
+              <p class="minihead">Observed By</p>
+              <span class="col-content">
+                <p>${domain}</p>
+                ${certFingerprintUrl
+                  ? html`<span
+                      ><a target="_blank" href="${certFingerprintUrl}"
+                        >View Certificate</a
+                      ></span
+                    >`
+                  : ""}
+              </span>
+            </div>
+          `
+        : software
+        ? html`
+            <div class="column">
+              <p class="minihead">Created With</p>
+              <div class="col-content">${software || "Unknown"}</div>
+            </div>
+          `
+        : ""}
+
+      <div class="column">
+        <p class="minihead">Validation</p>
+        <div class="col-content">
+          ${numValid > 0 || numInvalid > 0
+            ? html` <p>
+                ${numValid} hashes
+                verified${numInvalid ? html`, ${numInvalid} invalid` : ""}
+              </p>`
+            : html` Not Available`}
+        </div>
+      </div>
+
+      <div class="column">
+        <p class="minihead">Package Hash</p>
+        <div class="col-content">
+          ${datapackageHash || "Not Available"}
+          <a @click="${(e) => this.onCopy(e, datapackageHash)}" class="copy">
+            <fa-icon .svg="${fasCopy}"></fa-icon>
+          </a>
+        </div>
+      </div>
+
+      <div class="column">
+        <p class="minihead">Observer Public Key</p>
+        <div class="col-content">
+          ${publicKey || "Not Available"}
+          <a @click="${(e) => this.onCopy(e, publicKey)}" class="copy">
+            <fa-icon .svg="${fasCopy}"></fa-icon>
+          </a>
+        </div>
+      </div>
+
+      <div class="column">
+        <p class="minihead">Loading Mode</p>
+        <div class="col-content">
+          ${item.onDemand ? "Download On-Demand" : "Fully Local"}
+        </div>
+      </div>
+    </div>`;
+  }
+
+  render() {
+    return this.detailed ? this.renderDetailed() : this.renderSummaryView();
+  }
+
+  onCopy(event: Event, text: string | undefined) {
+    event.preventDefault();
+    event.stopPropagation();
+    if (text) navigator.clipboard.writeText(text);
+    return false;
+  }
+
+  onPurge(reload) {
+    const detail = { reload };
+    this.dispatchEvent(new CustomEvent("item-purge", { detail }));
+  }
+}
+
+customElements.define("wr-item-info", ItemInfo);
+
+export { ItemInfo };

--- a/src/replay.ts
+++ b/src/replay.ts
@@ -2,12 +2,12 @@ import { LitElement, html, css } from "lit";
 import { property } from "lit/decorators.js";
 
 import { wrapCss, rwpLogo } from "./misc";
-import type { Coll } from "./types";
+import type { Item } from "./types";
 
 // ===========================================================================
 class Replay extends LitElement {
   @property({ type: Object })
-  collInfo: Coll | Record<string, never> | null = null;
+  collInfo: Item | Record<string, never> | null = null;
 
   @property({ type: String })
   sourceUrl: any = null;

--- a/src/sorter.js
+++ b/src/sorter.js
@@ -3,8 +3,11 @@ import { wrapCss } from "./misc";
 
 import fasSortDown from "@fortawesome/fontawesome-free/svgs/solid/sort-down.svg";
 import fasSortUp from "@fortawesome/fontawesome-free/svgs/solid/sort-up.svg";
-
 // ===========================================================================
+/**
+ * @typedef {{key: string;name: string;}[]} SortKeys
+ * @prop {SortKeys} sortKeys
+ */
 class Sorter extends LitElement {
   constructor() {
     super();

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,4 +14,7 @@ export interface Coll {
   onDemand?: any;
   pages?: any[];
   lists?: any[];
+  ctime?: string;
+  totalSize?: unknown;
+  size?: unknown;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,8 +14,16 @@ export interface Item {
   desc?: string;
   description?: string;
   resources?: { path: string; name: string }[];
-  verify?: any;
-  onDemand?: any;
+  verify?: {
+    numValid?: number;
+    numInvalid?: number;
+    domain?: string;
+    certFingerprint?: string;
+    datapackageHash?: string;
+    publicKey?: string;
+    software?: string;
+  };
+  onDemand?: boolean;
   pages?: any[];
   lists?: any[];
   ctime?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,12 @@
-export interface Coll {
+export interface Item {
   filename: string;
   sourceUrl: string;
   replayPrefix: string;
   apiPrefix: string;
+
+  /**
+   * Archived Item ID
+   */
   coll?: string;
   name?: string;
   title?: string;

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,6 +1,6 @@
 import { ReplayWebApp } from "./appmain";
 import { Chooser } from "./chooser";
-import { CollIndex } from "./item-index";
+import { ItemIndex } from "./item-index";
 import { ItemInfo } from "./item-info";
 import { Item } from "./item";
 import { Story } from "./story";
@@ -17,7 +17,7 @@ import "./shoelace";
 export {
   ReplayWebApp,
   Chooser,
-  CollIndex,
+  ItemIndex as CollIndex, // @todo(2023-11-06) complete rename
   ItemInfo as CollInfo, // @todo(2023-11-06) complete rename
   Item as Coll, // @todo(2023-11-06) complete rename
   Story,

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,7 +1,8 @@
 import { ReplayWebApp } from "./appmain";
 import { Chooser } from "./chooser";
-import { CollIndex, CollInfo } from "./coll-index";
-import { Coll } from "./coll";
+import { CollIndex } from "./item-index";
+import { ItemInfo } from "./item-info";
+import { Item } from "./item";
 import { Story } from "./story";
 import { GDrive } from "./gdrive";
 import { Loader } from "./loader";
@@ -17,8 +18,8 @@ export {
   ReplayWebApp,
   Chooser,
   CollIndex,
-  CollInfo,
-  Coll,
+  ItemInfo as CollInfo, // @todo(2023-11-06) complete rename
+  Item as Coll, // @todo(2023-11-06) complete rename
   Story,
   GDrive,
   Loader,

--- a/src/url-resources.js
+++ b/src/url-resources.js
@@ -8,6 +8,9 @@ import fasSearch from "@fortawesome/fontawesome-free/svgs/solid/search.svg";
 import "keyword-mark-element/lib/keyword-mark.js";
 
 // ===========================================================================
+/**
+ * @prop {boolean | undefined} active
+ */
 class URLResources extends LitElement {
   static get filters() {
     return [


### PR DESCRIPTION
Closes #235 

## Summary

Moves the archive info from a tab into a dialog accessible via the dropdown menu alongside the address bar.

## Details

The dialog was implemented with [`sl-dialog`](https://shoelace.style/components/dialog).

Design moves closer to the 2.0 design, though not all the way — see attached screenshot. 
- Copy to clipboard buttons are now always visible, and show up on more fields
- Fields use a monospace treatment
- Item ID was moved up
- Description fields were removed, as per discussion with @Shrinks99 

I also:
- Improved some of the types, specifically doing better nullish checks, which also resulted in a couple additions to the shared `Item` type.
- Did some renaming of "coll" to "item" in the affected parts of the codebase
- Swapped the custom copy button to Shoelace's

## Screenshots

<img width="292" alt="Screenshot 2023-11-02 at 5 26 25 PM" src="https://github.com/webrecorder/replayweb.page/assets/5727389/ae8529f9-386a-4744-941b-0677bc167550">

<img width="528" alt="Screenshot 2023-11-06 at 6 27 13 PM" src="https://github.com/webrecorder/replayweb.page/assets/5727389/343dc52b-8d16-40f5-8a3d-adc2b35e9f79">



## Testing
Changes were tested by hand locally using various example WACZ files.