### PR TITLE
Adds GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/application-bug.yml
+++ b/.github/ISSUE_TEMPLATE/application-bug.yml
@@ -1,7 +1,7 @@
-name: Replay Bug Report
-description: "If archived content isn't displaying as expected, please file this type of issue!"
-title: "[Replay Bug]: "
-labels: ["replay bug", "bug"]
+name: Application Bug Report
+description: "If a feature of ReplayWeb.page isn't working as expected and you're sure your issue is reproducible, please file this type of issue!"
+title: "[Bug]: "
+labels: ["bug"]
 body:
   # Version number
   - type: input
@@ -12,30 +12,26 @@ body:
       placeholder: "v1.8.13"
     validations:
       required: true
-  # What did the user expect to happen? What was the actual behavior?
+# What did the user expect to happen? What was the actual behavior?
   - type: textarea
     attributes:
       label: What did you expect to happen? What happened instead?
       description: |
-        "On the live site, the element displays properly on hover. When replayed..."
+        "I was trying to search for content in a loaded archived item, however..."
 
         Please submit any screenshots/videos that can be used to understand how to reproduce the issue. You can attach images by clicking this area to highlight it and then dragging files into the browser window.
-        
-        Please include a link to any relevant archived items if possible.
     validations:
       required: true
   # Step-by-step reproduction instructions
   - type: textarea
     attributes:
       label: Step-by-step reproduction instructions
-      description: |
-        Please include step-by-step instructions for how to reproduce the issue if it is not immediately visible or already made clear in the above section.
       placeholder: |
         1. Navigate to...
         2. Click on...
         3. See error...
     validations:
-      required: false
+      required: true
   # Additional details
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+# Allow issues to be created without a template
+blank_issues_enabled: true
+
+contact_links:
+  - name: Report a security vulnerability
+    about: Please do not file an issue and instead email security@webrecorder.org. We will follow up with you there!
+    url: mailto:security@webrecorder.org
+  - name: Get help on our forum
+    url: https://forum.webrecorder.net/
+    about: Have a ("how do I...?") question? Not sure if your issue is reproducible? The best way to get help is on our community forum!

--- a/.github/ISSUE_TEMPLATE/feature-change.yml
+++ b/.github/ISSUE_TEMPLATE/feature-change.yml
@@ -1,0 +1,49 @@
+name: Feature / Change Request
+description: "If new things should be added or something that is working as intended should be changed, please file this type of issue!"
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  # Context
+  - type: textarea
+    attributes:
+      label: Context
+      description: "Describe any prior information that we are taking into account to inform this future development."
+      placeholder: "Now that x is done we should do y to accomplish z."
+    validations:
+      required: true
+  # User story sentence
+  - type: textarea
+    attributes:
+      label: What change would you like to see?
+      description: "Describe the solution you'd like. If relevant, include ways in which you've tried to solve the issue with the current version."
+      placeholder: "As a user, I want to be able to ____ so that I can ____"
+    validations:
+      required: true
+  # Requirements
+  - type: textarea
+    attributes:
+      label: Requirements
+      description: |
+        Intended primarily for use by Webrecorder team, leave blank if unknown.
+        
+        List the outcomes of the feature being implemented without design or implementation details.
+      placeholder: |
+        1. Item metadata should show links to the collections that the item belongs to.
+        2. Items can be added or removed from collections when editing an item.
+    validations:
+      required: false
+  # Todo
+  - type: textarea
+    attributes:
+      label: Todo
+      description: |
+        Intended primarily for use by Webrecorder team, leave blank if unknown.
+
+        Any other linked issues / tasks to complete to implement this feature.
+      placeholder: |
+        - [ ] Mockups: 
+        - [ ] Design: 
+        - [ ] UI: 
+        - [ ] API: 
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/replay-bug.yml
+++ b/.github/ISSUE_TEMPLATE/replay-bug.yml
@@ -1,0 +1,45 @@
+name: Replay Bug Report
+description: If archived content isn't displaying as expected, please file this type of issue!
+title: "[Replay Bug]: "
+labels: ["replay bug", "bug"]
+body:
+  # Version number
+  - type: input
+    id: version
+    attributes:
+      label: ReplayWeb.page Version
+      description: This can be found in the "About ReplayWeb.page" dialog
+      placeholder: "v1.8.13"
+    validations:
+      required: true
+  # What did the user expect to happen? What was the actual behavior?
+  - type: textarea
+    attributes:
+      label: What did you expect to happen? What happened instead?
+      description: |
+        "On the live site, the element displays properly on hover. When replayed..."
+
+        Please submit any screenshots/videos that can be used to understand how to reproduce the issue. You can attach images by clicking this area to highlight it and then dragging files into the browser window.
+        
+        Please include a link to any relevant archived items if possible.
+    validations:
+      required: true
+  # Step-by-step reproduction instructions
+  - type: textarea
+    attributes:
+      label: Step-by-step reproduction instructions
+      description: |
+        Please include step-by-step instructions for how to reproduce the issue if it is not immediately visible or already made clear in the above section.
+      placeholder: |
+        1. Navigate to...
+        2. Click on...
+        3. See error...
+    validations:
+      required: false
+  # Additional details
+  - type: textarea
+    attributes:
+      label: Additional details
+      description: Add any other relevant information here.
+    validations:
+      required: false


### PR DESCRIPTION
### Changes
- Adds the feature / change request form (no changes)
- Adds the bug report form (minor differences from Browsertrix based on app context, no major changes)
- Adds a replay specific bug report form
  - Makes reproduction steps optional asking the user to provide context in the above section.  Sometimes this isn't exactly required for replay bugs?
  - Changes text from our standard bug report form to fit context
  - Applies the new `replay bug` issue tag to filed issues.