### PR TITLE
Run build when installing from git repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "release": "yarn run build && electron-builder",
     "lint": "eslint ./",
     "format": "prettier --write ./",
-    "prepare": "husky install && yarn build"
+    "prepare": "husky install; node scripts/build-if-not-git-repo.js"
   },
   "build": {
     "afterSign": "build/notarize.js",
@@ -102,7 +102,9 @@
       "dist/*.js",
       "dist/prebuilds/${platform}-${arch}/*",
       "dist/build/*",
-      "*.js",
+      "index.js",
+      "ui.js",
+      "sw.js",
       "*.html",
       "ruffle",
       "webmanifest.json",

--- a/scripts/build-if-not-git-repo.js
+++ b/scripts/build-if-not-git-repo.js
@@ -1,0 +1,45 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-env node */
+
+// Runs a webpack build when not installed in a git repository (i.e. when installed from GitHub in node_modules)
+// Largely pulled from https://github.com/typicode/husky/blob/9d3eb31cd14d3fbdb77225d23a0c5a11f71beb2c/src/index.ts#L23
+
+const cp = require("child_process");
+
+const webpack = require("webpack");
+const config = require("../webpack.config.js");
+
+/**
+ * Logger
+ * @param {string} msg
+ * @returns {void}
+ */
+const l = (msg) => console.log(`replaywebpage - ${msg}`);
+
+/**
+ * Git command
+ * @param {string[]} args
+ * @returns {cp.SpawnSyncReturns<Buffer>}
+ */
+const git = (args) => cp.spawnSync("git", args, { stdio: "inherit" });
+
+// Ensure that we're inside a Git repository
+// If git command is not found, status is null and we should return
+// That's why status value needs to be checked explicitly
+if (git(["rev-parse"]).status !== 0) {
+  l(`git command not found, running build`);
+  const compiler = webpack(config.map((c) => c()));
+
+  compiler.run((err) => {
+    if (err) {
+      console.error(err);
+      process.exit(1);
+    }
+    compiler.close((err) => {
+      if (err) {
+        console.error(err);
+        process.exit(1);
+      }
+    });
+  });
+}


### PR DESCRIPTION
Adds [scripts/build-if-not-git-repo.js](https://github.com/webrecorder/replayweb.page/compare/dev-2.0.0...testing-npm-scripts?expand=1#diff-84ba66c4ebe237b1827114743c8d9d086ce6f2d7edf7e0892fd01a567114f2f4) that runs a rebuild only when installing in `node_modules` (or in other situations where not a git repo) to the `prepare` npm script. This follows the same pattern that `husky` uses for its `prepare` script.

Also more explicitly lists files included in `files` field in `package.json` so that we're not also packaging webpack and eslint configs in with built files.

# Testing

Tested by hand using this branch and `archiveweb.page` with `yarn add git+https://github.com/webrecorder/replayweb.page.git#testing-npm-scripts` and then manually inspecting `node_modules/replaywebpage`