### PR TITLE
Removes plausible from Index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,6 @@
 <title>ReplayWeb.page</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <script src="./ui.js"></script>
-<script defer="" data-domain="replayweb.page" src="https://stats.browsertrix.com/js/script.js"></script>
 </head>
 <body>
 <replay-app-main></replay-app-main>


### PR DESCRIPTION
Looks like this gives us more information than we bargianed for.

1. index.html is shipped with the ReplayWebpage package (and possibly used elsewhere?) and we don't want to be collecting analytics on where people use it in their projects
2. File names and paths are sent to Plausible if used as an external referrer to ReplayWebpage.  This lets us see referring sources such as `https://beta.browsertrix.cloud/api/orgs/{orgid}}/collections/{collectionid}]/public/replay.json` or `file://myfile.wacz`.  Directory structures are not exposed in this data, only the file name.

### Changes
- Removes plausible on index.html