### PR TITLE
[docs] List .wacz as a supported format

### DIFF
--- a/docs/formats.md
+++ b/docs/formats.md
@@ -12,9 +12,6 @@ parent: Reference
 ReplayWeb.Page supports the archive formats listed below.
 Format is currently determined based on the file extension.
 
-The `.wacz` refers to the newly proposed [Web Archive Collection Zip Format](wacz-format).
-
-
 | Format  | Extensions          | Status        |     
 |:--------|:--------------------|:--------------|
 | WARC    | `.warc`, `.warc.gz` | <span class="d-inline-block p-2 mr-1 v-align-middle bg-green-000"> Supported     |
@@ -22,7 +19,7 @@ The `.wacz` refers to the newly proposed [Web Archive Collection Zip Format](wac
 | WBN     | `.wbn`              | <span class="d-inline-block p-2 mr-1 v-align-middle bg-yellow-000"> Experimental  | 
 | ARC     | `.arc`              | <span class="d-inline-block p-2 mr-1 v-align-middle bg-red-000"> Not Supported |
 | CDX     | `.cdx`, `.cdxj`     | <span class="d-inline-block p-2 mr-1 v-align-middle bg-green-000"> Supported |
-| WACZ    | `.wacz`             | <span class="d-inline-block p-2 mr-1 v-align-middle bg-yellow-000"> In Progress |
+| WACZ    | `.wacz`             | <span class="d-inline-block p-2 mr-1 v-align-middle bg-yellow-000"> Supported |
 
 
 


### PR DESCRIPTION
https://replayweb.page/docs/wacz-format lists .wacz as a supported format: 

> ReplayWeb.page _supports_ a new format for bundling raw web archive data (usually WARC files), indices, page lists and other metadata into a single ZIP file.

This commit brings the "supported formats" page in line with this wording,  as well as the fact that, nowadays. uploading .wacz files works about as well as .warc files. 

Also removed the "new" classifier because while true when formats.md was created,  some four years later, .wacz has been adopted by multiple downstream projects. 