### PR TITLE
Tab list disappears with an empty WARC

### DIFF
--- a/src/item.ts
+++ b/src/item.ts
@@ -597,6 +597,7 @@ class Item extends LitElement {
         display: flex;
         flex-direction: row;
         margin-bottom: 0px;
+        overflow: unset;
       }
 
       .main.tabs ul {
@@ -605,7 +606,7 @@ class Item extends LitElement {
 
       .main.tabs li {
         line-height: 1.5;
-        padding: 8px 0 6px 0;
+        padding: 6px 0 4px 0;
       }
 
       @media screen and (max-width: 319px) {


### PR DESCRIPTION
Closes #283 

Not too sure what the root of the problem actually is, but removing the overflow seems to fix it, though it does change the sizing somewhat. I've adjusted the padding to compensate, so it should look the same as it did before.

The source rules are coming from Bulma, which I don't know super well, so I don't mind overriding it in this context rather than trying to fix the underlying issue here.