### PR TITLE
Typescript config parity with Browsertrix repo

### DIFF
--- a/src/appmain.ts
+++ b/src/appmain.ts
@@ -480,6 +480,7 @@ export class ReplayWebApp extends LitElement {
     }
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onFavIcons(event) {
     const head = document.querySelector("head")!;
     const oldLinks = document.querySelectorAll("link[rel*='icon']");
@@ -496,6 +497,7 @@ export class ReplayWebApp extends LitElement {
     }
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   skipMenu(event) {
     // This is a workaround, since this app's routing doesn't permit normal
     // following of in-page anchors.
@@ -503,6 +505,7 @@ export class ReplayWebApp extends LitElement {
     this.renderRoot.querySelector<HTMLElement>("#skip-main-target")?.focus();
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onNavMenu(event) {
     event.preventDefault();
     event.stopPropagation();
@@ -644,6 +647,7 @@ export class ReplayWebApp extends LitElement {
     }
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onStartLoad(event) {
     // just redirect right away?
     // TODO: Fix this the next time the file is edited.
@@ -665,6 +669,7 @@ export class ReplayWebApp extends LitElement {
     this.loadInfo = event.detail;
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onCollLoaded(event) {
     this.loadInfo = null;
     if (event.detail.collInfo) {
@@ -687,6 +692,7 @@ export class ReplayWebApp extends LitElement {
     }
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onTitle(event) {
     if (event.detail.title) {
       this.pageTitle = event.detail.title;

--- a/src/chooser.ts
+++ b/src/chooser.ts
@@ -77,6 +77,7 @@ export class Chooser extends LitElement {
     }
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onChooseFile(event) {
     if (event.currentTarget.files.length === 0) {
       return;
@@ -167,6 +168,7 @@ export class Chooser extends LitElement {
     return false;
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onInput(event) {
     this.fileDisplayName = event.currentTarget.value;
 
@@ -255,7 +257,10 @@ export class Chooser extends LitElement {
               ${!this.hasNativeFS
                 ? html` <input
                     class="file-input"
-                    @click="${(e) => (e.currentTarget.value = null)}"
+                    @click="${
+                      // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'e' implicitly has an 'any' type.
+                      (e) => (e.currentTarget.value = null)
+                    }"
                     @change=${this.onChooseFile}
                     type="file"
                     id="fileupload"

--- a/src/electron-preload.ts
+++ b/src/electron-preload.ts
@@ -1,5 +1,6 @@
 /*eslint-env node */
 
+// @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7016 - Could not find a declaration file for module '@webrecorder/wabac/src/loaders'. 'node_modules/@webrecorder/wabac/src/loaders.js' implicitly has an 'any' type.
 import { CollectionLoader } from "@webrecorder/wabac/src/loaders";
 import { type IpcRendererEvent } from "electron";
 
@@ -12,11 +13,15 @@ const dbs = {};
 const loader = new CollectionLoader();
 
 async function getColl(name: string) {
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7053 - Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
   if (!dbs[name]) {
+    // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7053 - Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
     dbs[name] = await loader.loadColl(name);
+    // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7053 - Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
     await dbs[name].initing;
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7053 - Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
   // TODO: Fix this the next time the file is edited.
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return dbs[name];

--- a/src/electron-replay-app.ts
+++ b/src/electron-replay-app.ts
@@ -16,6 +16,7 @@ import {
 import path from "path";
 import fs from "fs";
 
+// @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7016 - Could not find a declaration file for module '@webrecorder/wabac/src/rewrite'. 'node_modules/@webrecorder/wabac/src/rewrite/index.js' implicitly has an 'any' type.
 import { ArchiveResponse, Rewriter } from "@webrecorder/wabac/src/rewrite";
 
 import { PassThrough, Readable } from "stream";
@@ -23,6 +24,7 @@ import { PassThrough, Readable } from "stream";
 import { autoUpdater } from "electron-updater";
 import log from "electron-log";
 
+// @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7016 - Could not find a declaration file for module 'mime-types'. 'node_modules/mime-types/index.js' implicitly has an 'any' type.
 import mime from "mime-types";
 import url from "url";
 
@@ -214,6 +216,7 @@ class ElectronReplayApp {
     this.mainWindow = this.createMainWindow(process.argv);
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'request' implicitly has an 'any' type. | TS7006 - Parameter 'callback' implicitly has an 'any' type.
   async doHandleFile(request, callback) {
     //const parsedUrl = new URL(request.url);
     //const filename = parsedUrl.searchParams.get("filename");
@@ -259,6 +262,7 @@ class ElectronReplayApp {
     }
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'data' implicitly has an 'any' type.
   _bufferToStream(data) {
     const rv = new PassThrough();
     rv.push(data);
@@ -267,6 +271,7 @@ class ElectronReplayApp {
   }
 
   async doIntercept(
+    // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'request' implicitly has an 'any' type.
     request,
     callback: (response: {
       statusCode: number;
@@ -337,6 +342,7 @@ class ElectronReplayApp {
     await this.proxyLive(request, callback);
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'request' implicitly has an 'any' type. | TS7006 - Parameter 'callback' implicitly has an 'any' type.
   async proxyLive(request, callback) {
     let headers = request.headers;
     const { method, url, uploadData } = request;
@@ -364,8 +370,6 @@ class ElectronReplayApp {
     const data = method === "HEAD" ? null : response.body;
     const statusCode = response.status;
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     headers = Object.fromEntries(response.headers.entries());
     callback({ statusCode, headers, data });
   }
@@ -379,6 +383,7 @@ class ElectronReplayApp {
    *    data: unknown;
    * }) => void} callback
    */
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'url' implicitly has an 'any' type. | TS7006 - Parameter 'callback' implicitly has an 'any' type.
   notFound(url, callback) {
     console.log("not found: " + url);
     const data = this._bufferToStream(
@@ -391,6 +396,7 @@ class ElectronReplayApp {
     });
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'request' implicitly has an 'any' type. | TS7006 - Parameter 'callback' implicitly has an 'any' type.
   async resolveArchiveResponse(request, callback) {
     const channel = `req:${new Date().getTime()}:${request.url}`;
 
@@ -469,6 +475,7 @@ class ElectronReplayApp {
     }
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'reqHeaders' implicitly has an 'any' type. | TS7006 - Parameter 'headers' implicitly has an 'any' type. | TS7006 - Parameter 'size' implicitly has an 'any' type.
   parseRange(reqHeaders, headers, size) {
     let statusCode = 200;
     const range = reqHeaders.get("range");
@@ -495,6 +502,7 @@ class ElectronReplayApp {
     return { statusCode, start, end };
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'argv' implicitly has an 'any' type.
   createMainWindow(argv) {
     const sourceString = this.getOpenUrl(argv);
 
@@ -521,6 +529,7 @@ class ElectronReplayApp {
     return theWindow;
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'argv' implicitly has an 'any' type.
   getOpenUrl(argv) {
     argv = require("minimist")(argv.slice(process.defaultApp ? 2 : 1));
 
@@ -565,6 +574,7 @@ class ElectronReplayApp {
   }
 }
 
+// @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'body' implicitly has an 'any' type. | TS7006 - Parameter 'session' implicitly has an 'any' type.
 async function* readBody(body, session) {
   for (const chunk of body) {
     if (chunk.bytes) {

--- a/src/embed-receipt.ts
+++ b/src/embed-receipt.ts
@@ -357,6 +357,7 @@ export class RWPEmbedReceipt extends LitElement {
     `;
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onEmbedDrop(event) {
     event.stopPropagation();
     this.active = !this.active;

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -24,7 +24,9 @@ class Embed extends LitElement {
   @property({ type: String }) ts = "";
   @property({ type: String }) query = "";
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7008 - Member 'source' implicitly has an 'any' type.
   @property({ type: String }) source;
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7008 - Member 'src' implicitly has an 'any' type.
   @property({ type: String }) src;
 
   @property({ type: String }) view = "replay";
@@ -57,6 +59,7 @@ class Embed extends LitElement {
     | string
     | undefined;
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7008 - Member 'requireSubdomainIframe' implicitly has an 'any' type.
   @property({ type: Boolean }) requireSubdomainIframe;
 
   @property({ type: String }) loading = "";
@@ -73,6 +76,7 @@ class Embed extends LitElement {
   isCrossOrigin: boolean | undefined;
   swmanager: SWManager | undefined;
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'replayfile' implicitly has an 'any' type.
   static setDefaultReplayFile(replayfile) {
     defaultReplayFile = replayfile;
   }
@@ -109,6 +113,7 @@ class Embed extends LitElement {
     }
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   handleMessage(event) {
     const iframe = this.renderRoot.querySelector("iframe");
 
@@ -353,6 +358,7 @@ class Embed extends LitElement {
     `;
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onLoad(event) {
     if (this.isCrossOrigin) {
       return;

--- a/src/gdrive.ts
+++ b/src/gdrive.ts
@@ -97,6 +97,7 @@ class GDrive extends LitElement {
 
   onLoad() {
     this.scriptLoaded = true;
+    // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'response' implicitly has an 'any' type.
     this.gauth("none", (response) => {
       if (response.error) {
         if (this.state !== "implicitonly") {
@@ -111,6 +112,7 @@ class GDrive extends LitElement {
   }
 
   onClickAuth() {
+    // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'response' implicitly has an 'any' type.
     this.gauth("select_account", (response) => {
       if (!response.error) {
         // TODO: Fix this the next time the file is edited.
@@ -120,6 +122,7 @@ class GDrive extends LitElement {
     });
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'response' implicitly has an 'any' type.
   async authed(response) {
     const sourceUrl = this.sourceUrl;
     const fileId = sourceUrl.slice("googledrive://".length);
@@ -200,6 +203,7 @@ class GDrive extends LitElement {
     return script;
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'prompt' implicitly has an 'any' type. | TS7006 - Parameter 'callback' implicitly has an 'any' type.
   gauth(prompt, callback) {
     self.gapi.load("auth2", () => {
       self.gapi.auth2.authorize(

--- a/src/item-index.ts
+++ b/src/item-index.ts
@@ -120,6 +120,7 @@ class ItemIndex extends LitElement {
     }
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   async onDeleteItem(event) {
     event.preventDefault();
     event.stopPropagation();

--- a/src/item-info.ts
+++ b/src/item-info.ts
@@ -240,6 +240,7 @@ class ItemInfo extends LitElement {
     return false;
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'reload' implicitly has an 'any' type.
   onPurge(reload) {
     const detail = { reload };
     this.dispatchEvent(new CustomEvent("item-purge", { detail }));

--- a/src/item.ts
+++ b/src/item.ts
@@ -257,8 +257,10 @@ class Item extends LitElement {
       Object.entries(this.tabData).forEach(([key, value]) => {
         if (!value) return;
         if (key === "multiTs" && typeof value === "string") {
+          // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7053 - Element implicitly has an 'any' type because expression of type '"multiTs"' can't be used to index type '{}'.
           tabData[key] = value.split(",");
         } else {
+          // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7053 - Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
           tabData[key] = value;
         }
       });
@@ -447,6 +449,7 @@ class Item extends LitElement {
     this.onHashChange();
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onItemLoaded(event) {
     // TODO: Fix this the next time the file is edited.
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -465,6 +468,7 @@ class Item extends LitElement {
     );
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onItemUpdate(event) {
     if (!this.editable) {
       return;
@@ -522,6 +526,7 @@ class Item extends LitElement {
     }
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onTabClick(event) {
     event.preventDefault();
     const hash = event.currentTarget.getAttribute("href");
@@ -530,6 +535,7 @@ class Item extends LitElement {
     return false;
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onItemTabNav(event) {
     if (event.detail.reload) {
       this.onRefresh(null, true);
@@ -556,6 +562,7 @@ class Item extends LitElement {
     }
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'data' implicitly has an 'any' type.
   updateTabData(data, replaceLoc = false /*, merge = false*/) {
     this.tabData = { ...this.tabData, ...data };
     if (this.tabData.url) {
@@ -961,6 +968,7 @@ class Item extends LitElement {
     }
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'isSidebar' implicitly has an 'any' type.
   renderTabHeader(isSidebar) {
     // if (this.tabData.view === "replay") {
     //   return "";
@@ -1536,6 +1544,7 @@ class Item extends LitElement {
     return "";
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'isSidebar' implicitly has an 'any' type.
   renderItemTabs(isSidebar) {
     const isStory = this.hasStory && this.tabData.view === "story";
     const isPages = this.tabData.view === "pages";
@@ -1603,6 +1612,7 @@ class Item extends LitElement {
     `;
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   skipMenu(event) {
     // This is a workaround, since this app's routing doesn't permit normal
     // following of in-page anchors.
@@ -1610,6 +1620,7 @@ class Item extends LitElement {
     this.renderRoot.querySelector<HTMLElement>("#skip-replay-target")?.focus();
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onKeyDown(event) {
     if (event.key === "Esc" || event.key === "Escape") {
       event.preventDefault();
@@ -1617,6 +1628,7 @@ class Item extends LitElement {
     }
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onMenu(event) {
     event.stopPropagation();
     this.menuActive = !this.menuActive;
@@ -1632,6 +1644,7 @@ class Item extends LitElement {
     }
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onFullscreenToggle(event) {
     event.preventDefault();
     this.menuActive = false;
@@ -1646,18 +1659,21 @@ class Item extends LitElement {
     }
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onGoBack(event) {
     event.preventDefault();
     this.menuActive = false;
     window.history.back();
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onGoForward(event) {
     event.preventDefault();
     this.menuActive = false;
     window.history.forward();
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onShowPages(event) {
     event.preventDefault();
     // show sidebar for tablet or wider, or hide sidebar
@@ -1670,16 +1686,19 @@ class Item extends LitElement {
     }
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onFullPageView(event) {
     event.preventDefault();
     this.updateTabData({ url: "", ts: "" });
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onHideSidebar(event) {
     event.preventDefault();
     this.showSidebar = false;
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   async onFavIcons(event) {
     for (const icon of event.detail.icons) {
       // TODO: Fix this the next time the file is edited.
@@ -1698,6 +1717,7 @@ class Item extends LitElement {
     this.favIconUrl = "";
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onPurgeCache(event) {
     event.preventDefault();
 
@@ -1731,6 +1751,7 @@ class Item extends LitElement {
     window.location.reload();
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onSubmit(event) {
     event.preventDefault();
     const input = this.renderRoot.querySelector<HTMLInputElement>("input")!;
@@ -1742,6 +1763,7 @@ class Item extends LitElement {
     return false;
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onLostFocus(event) {
     if (!event.currentTarget.value) {
       event.currentTarget.value = this.url;
@@ -1769,6 +1791,7 @@ class Item extends LitElement {
     this.updateTabData({ ts: item.value });
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'value' implicitly has an 'any' type.
   navigateTo(value) {
     let data;
 
@@ -1792,6 +1815,7 @@ class Item extends LitElement {
     this.updateTabData(data);
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'value' implicitly has an 'any' type.
   _stringToParams(value) {
     // TODO: Fix this the next time the file is edited.
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
@@ -1808,6 +1832,7 @@ class Item extends LitElement {
       "urlSearchType",
     ]) {
       if (q.has(param)) {
+        // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7053 - Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Partial<URLResource>'.
         data[param] = q.get(param);
       }
     }

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -199,7 +199,6 @@ You can select a file to upload from the main page by clicking the 'Choose File.
       }
       // todo: too special case?
       if (sourceUrl!.startsWith("proxy:") && extraConfig?.recording) {
-        // @ts-expect-error - TS2322 - Type '"recordingproxy"' is not assignable to type 'undefined'.
         type = "recordingproxy";
       }
     }

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -29,6 +29,7 @@ const VERSION = __VERSION__;
 // ===========================================================================
 // Buttons are expected to respond to both enter/return and spacebar.
 // If using `<a>` with `role='button'`, assign this handler to keyup.
+// @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
 function clickOnSpacebarPress(event) {
   if (event.key == " ") {
     event.preventDefault();

--- a/src/pageentry.ts
+++ b/src/pageentry.ts
@@ -386,6 +386,7 @@ class PageEntry extends LitElement {
     return this.onReplay(event, true);
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'data' implicitly has an 'any' type.
   sendChangeEvent(data, reload: boolean) {
     this.dispatchEvent(
       new CustomEvent("coll-tab-nav", {
@@ -401,6 +402,7 @@ class PageEntry extends LitElement {
     this.dispatchEvent(new CustomEvent("delete-page", { detail: { page } }));
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onSendSelToggle(event) {
     const page = this.page!.id;
     const selected = event.currentTarget.checked;

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -249,10 +249,12 @@ class Pages extends LitElement {
     this.filteredPages = curated;
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'data' implicitly has an 'any' type.
   sendChangeEvent(data) {
     this.dispatchEvent(new CustomEvent("coll-tab-nav", { detail: { data } }));
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'pages' implicitly has an 'any' type.
   // TODO: Fix this the next time the file is edited.
   // eslint-disable-next-line @typescript-eslint/promise-function-async
   addPages(pages) {
@@ -268,6 +270,7 @@ class Pages extends LitElement {
     );
 
     return Promise.all(
+      // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'page' implicitly has an 'any' type. | TS7006 - Parameter 'index' implicitly has an 'any' type.
       // TODO: Fix this the next time the file is edited.
       // eslint-disable-next-line @typescript-eslint/promise-function-async
       pages.map((page, index) => {
@@ -573,11 +576,13 @@ class Pages extends LitElement {
     `;
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onSelectList(event) {
     event.preventDefault();
     this.currList = Number(event.currentTarget.getAttribute("data-list"));
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onSelectListDrop(event) {
     event.preventDefault();
     this.currList = Number(event.currentTarget.value);
@@ -744,6 +749,7 @@ class Pages extends LitElement {
             role="button"
             href="#"
             @click="${
+              // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'e' implicitly has an 'any' type.
               // TODO: Fix this the next time the file is edited.
               // eslint-disable-next-line @typescript-eslint/promise-function-async
               (e) => this.onDownload(e, "wacz")
@@ -758,6 +764,7 @@ class Pages extends LitElement {
             role="button"
             href="#"
             @click="${
+              // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'e' implicitly has an 'any' type.
               // TODO: Fix this the next time the file is edited.
               // eslint-disable-next-line @typescript-eslint/promise-function-async
               (e) => this.onDownload(e, "warc")
@@ -772,6 +779,7 @@ class Pages extends LitElement {
             role="button"
             href="#"
             @click="${
+              // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'e' implicitly has an 'any' type.
               // TODO: Fix this the next time the file is edited.
               // eslint-disable-next-line @typescript-eslint/promise-function-async
               (e) => this.onDownload(e, "warc1.0")
@@ -910,6 +918,7 @@ class Pages extends LitElement {
     </wr-modal>`;
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'page' implicitly has an 'any' type.
   isCurrPage(page) {
     if (this.isSidebar) {
       if (page.url === this.url) {
@@ -964,6 +973,7 @@ class Pages extends LitElement {
     `;
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onUpdateTitle(event) {
     event.preventDefault();
 
@@ -995,6 +1005,7 @@ class Pages extends LitElement {
     });
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onMenu(event) {
     event.stopPropagation();
     this.menuActive = !this.menuActive;
@@ -1010,6 +1021,7 @@ class Pages extends LitElement {
     }
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onSort(event) {
     event.preventDefault();
 
@@ -1022,12 +1034,14 @@ class Pages extends LitElement {
     }
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onSortChanged(event) {
     this.sortedPages = event.detail.sortedData;
     this.sortKey = event.detail.sortKey;
     this.sortDesc = event.detail.sortDesc;
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onSelectToggle(event) {
     const { page, selected } = event.detail;
     if (selected) {
@@ -1043,6 +1057,7 @@ class Pages extends LitElement {
     this.requestUpdate();
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onSelectAll(event) {
     this.allSelected = event.currentTarget.checked;
     if (!this.allSelected) {
@@ -1057,6 +1072,7 @@ class Pages extends LitElement {
     this.requestUpdate();
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type. | TS7006 - Parameter 'format' implicitly has an 'any' type.
   async onDownload(event, format) {
     event.preventDefault();
 
@@ -1100,6 +1116,7 @@ class Pages extends LitElement {
       );
       if (p) {
         p.deleting = true;
+        // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7053 - Element implicitly has an 'any' type because expression of type 'number' can't be used to index type '{}'.
         pageMap[id] = p;
       }
     }
@@ -1115,6 +1132,7 @@ class Pages extends LitElement {
         continue;
       }
 
+      // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7053 - Element implicitly has an 'any' type because expression of type 'number' can't be used to index type '{}'.
       const page = pageMap[id];
 
       if (!page) {
@@ -1185,6 +1203,7 @@ class Pages extends LitElement {
     return "No Pages Found";
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onScroll(event) {
     const element = event.currentTarget;
     const diff =

--- a/src/replay.ts
+++ b/src/replay.ts
@@ -55,6 +55,7 @@ class Replay extends LitElement {
     );
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   async handleAuthMessage(event) {
     if (
       event.data.type === "authneeded" &&
@@ -202,6 +203,7 @@ class Replay extends LitElement {
     }
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onReAuthed(event) {
     this.reauthWait = (async () => {
       if (!this.authFileHandle) {
@@ -246,6 +248,7 @@ class Replay extends LitElement {
     }, 5000);
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'iframeWin' implicitly has an 'any' type.
   clearLoading(iframeWin) {
     this.dispatchEvent(
       new CustomEvent("replay-loading", { detail: { loading: false } }),

--- a/src/sorter.ts
+++ b/src/sorter.ts
@@ -74,10 +74,12 @@ class Sorter<T = unknown> extends LitElement {
       }
     } else {
       this.sortedData.sort((first, second) => {
+        // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7053 - Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'unknown'. | TS7053 - Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'unknown'.
         if (first[this.sortKey!] === second[this.sortKey!]) {
           return 0;
         }
 
+        // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7053 - Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'unknown'. | TS7053 - Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'unknown'.
         return this.sortDesc == first[this.sortKey!] < second[this.sortKey!]
           ? 1
           : -1;

--- a/src/story.ts
+++ b/src/story.ts
@@ -2,6 +2,7 @@ import { LitElement, html, css, unsafeCSS, type PropertyValues } from "lit";
 import { wrapCss } from "./misc";
 
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
+// @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7016 - Could not find a declaration file for module 'marked'. 'node_modules/marked/lib/marked.cjs' implicitly has an 'any' type.
 import { marked } from "marked";
 
 import { getTS, getReplayLink } from "./pageutils";
@@ -114,6 +115,7 @@ class Story extends LitElement {
     const pageMap = {};
 
     for (const page of this.collInfo.pages) {
+      // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7053 - Element implicitly has an 'any' type because expression of type 'number' can't be used to index type '{}'.
       pageMap[page.id] = page;
     }
 
@@ -339,6 +341,7 @@ class Story extends LitElement {
     )}`;
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'p' implicitly has an 'any' type.
   renderCPage(p) {
     // TODO: Fix this the next time the file is edited.
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
@@ -378,10 +381,12 @@ class Story extends LitElement {
     return false;
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'data' implicitly has an 'any' type.
   sendChangeEvent(data) {
     this.dispatchEvent(new CustomEvent("coll-tab-nav", { detail: { data } }));
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onClickScroll(event) {
     event.preventDefault();
     //this.pageView = false;

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,7 +1,9 @@
 import INDEX_HTML from "../index.html";
 
+// @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7016 - Could not find a declaration file for module '@webrecorder/wabac/src/swmain'. 'node_modules/@webrecorder/wabac/src/swmain.js' implicitly has an 'any' type.
 import { SWReplay } from "@webrecorder/wabac/src/swmain";
 
+// @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7016 - Could not find a declaration file for module '@webrecorder/wabac/src/loaders'. 'node_modules/@webrecorder/wabac/src/loaders.js' implicitly has an 'any' type.
 import { WorkerLoader } from "@webrecorder/wabac/src/loaders";
 
 type Self = Window &

--- a/src/swmanager.ts
+++ b/src/swmanager.ts
@@ -22,6 +22,7 @@ export class SWManager {
     this.errorMsg = null;
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'newAppName' implicitly has an 'any' type.
   setAppName(newAppName) {
     // @ts-expect-error - TS2339 - Property 'appName' does not exist on type 'SWManager'.
     this.appName = newAppName;
@@ -30,6 +31,7 @@ export class SWManager {
   // TODO: Fix this the next time the file is edited.
   // eslint-disable-next-line @typescript-eslint/promise-function-async
   register() {
+    // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7034 - Variable 'resolve' implicitly has type 'any' in some locations where its type cannot be determined. | TS7034 - Variable 'reject' implicitly has type 'any' in some locations where its type cannot be determined.
     let resolve, reject;
 
     const p = new Promise((res, rej) => {
@@ -48,6 +50,7 @@ export class SWManager {
       reject(this.errorMsg);
     }
 
+    // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'error' implicitly has an 'any' type.
     const handleError = (error) => {
       console.error("Error during service worker registration:", error);
       // @ts-expect-error - TS2339 - Property 'errorMsg' does not exist on type 'SWManager'.
@@ -73,6 +76,7 @@ export class SWManager {
       registrationOptions: { scope: this.scope },
       registered() {
         console.log("Service worker is registered");
+        // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7005 - Variable 'resolve' implicitly has an 'any' type.
         resolve();
       },
 

--- a/src/url-resources.ts
+++ b/src/url-resources.ts
@@ -202,10 +202,12 @@ class URLResources extends LitElement {
     this.loading = false;
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onChangeTypeSearch(event) {
     this.currMime = event.currentTarget.value;
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onChangeQuery(event) {
     this.newQuery = event.currentTarget.value;
     if (this._ival) {
@@ -214,6 +216,7 @@ class URLResources extends LitElement {
     this._ival = window.setTimeout(() => this._timedUpdate(), 250);
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onClickUrlType(event) {
     this.urlSearchType = event.currentTarget.value;
   }
@@ -230,6 +233,7 @@ class URLResources extends LitElement {
     this.filteredResults = filteredResults;
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onScroll(event) {
     const element = event.currentTarget;
     const diff =
@@ -566,6 +570,7 @@ class URLResources extends LitElement {
     `;
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onSort(event) {
     event.preventDefault();
 
@@ -578,12 +583,14 @@ class URLResources extends LitElement {
     }
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onSortChanged(event) {
     this.sortedResults = event.detail.sortedData;
     this.sortKey = event.detail.sortKey;
     this.sortDesc = event.detail.sortDesc;
   }
 
+  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onReplay(event) {
     event.preventDefault();
     const data = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,33 +9,27 @@
     "declaration": true,
     "declarationMap": true,
     "declarationDir": "./dist/types",
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
     "importHelpers": true,
     "sourceMap": true,
     "inlineSources": true,
-    "paths": {
-      "flexsearch": ["./node_modules/@types/flexsearch"]
-    },
+    "skipLibCheck": true,
     "plugins": [
       {
         "name": "ts-lit-plugin",
         "strict": true,
         "rules": {
-          // This seems to produce a bunch of false positives, so we've turned it off for now.
-          // Relevant issues:
-          // https://github.com/runem/lit-analyzer/issues/293
-          // https://github.com/runem/lit-analyzer/issues/302
-          // https://github.com/runem/lit-analyzer/issues/266
-          "no-missing-import": "off",
-
-          // ts-lit-plugin also doesn't seem to understand string interpolations in CSS, so this is also turned off.
-          "no-invalid-css": "off"
-        }
+          "no-missing-import": "off"
+        },
+        "maxNodeModuleImportDepth": -1
       }
     ],
-    "skipLibCheck": true
+    "incremental": true,
+    "paths": {
+      "flexsearch": ["./node_modules/@types/flexsearch"]
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.d.ts"]
 }


### PR DESCRIPTION
Follow-up from #288 

This matches the strictness rules with the Browsertrix repo, specifically `noImplicitAny`, and then adds `// @ts-expect-error`s to suppress existing errors this change raises. This'll help us keep code quality high moving forward.

Going to just directly merge this once it passes CI; as with #288, this doesn't change any code, just comments.