### PR TITLE
2.0 UX Changes

### DIFF
--- a/src/chooser.ts
+++ b/src/chooser.ts
@@ -295,10 +295,7 @@ export class Chooser extends LitElement {
                 />
               </p>
               <div class="control">
-                <button
-                  type="submit"
-                  class="button is-hidden-mobile is-primary"
-                >
+                <button type="submit" class="button is-primary">
                   ${this.newFullImport ? "Import" : "Load"}
                 </button>
               </div>

--- a/src/item.ts
+++ b/src/item.ts
@@ -989,53 +989,57 @@ class Item extends LitElement {
       aria-label="tabs"
     >
       <ul>
-        ${isSidebar
-          ? html` <li class="sidebar-nav left">
-              <a
-                role="button"
-                href="#"
-                @click="${this.onHideSidebar}"
-                @keyup="${clickOnSpacebarPress}"
-                class="is-marginless is-size-6 is-paddingless"
-              >
-                <fa-icon
-                  title="Hide"
-                  .svg="${fasAngleLeft}"
-                  aria-hidden="true"
-                ></fa-icon>
-                <span class="nav-hover" aria-hidden="true">Hide</span>
-                <span class="is-sr-only">Hide Sidebar</span>
-              </a>
-            </li>`
-          : ""}
-        ${this.hasStory
-          ? html` <li
-              class="${this.tabData.view === "story" ? "is-active" : ""}"
-            >
-              <a
-                @click="${this.onTabClick}"
-                href="#story"
-                class="is-size-6"
-                aria-label="Story"
-                aria-current="${ifDefined(
-                  this.tabData.view === "story" ? "location" : undefined,
-                )}"
-              >
-                <span class="icon"
-                  ><fa-icon
-                    .svg="${fasBook}"
-                    aria-hidden="true"
-                    title="Story"
-                  ></fa-icon
-                ></span>
-                <span
-                  class="tab-label ${isSidebar ? "is-hidden" : ""}"
-                  title="Story"
-                  >Story</span
+        ${
+          isSidebar
+            ? html` <li class="sidebar-nav left">
+                <a
+                  role="button"
+                  href="#"
+                  @click="${this.onHideSidebar}"
+                  @keyup="${clickOnSpacebarPress}"
+                  class="is-marginless is-size-6 is-paddingless"
                 >
-              </a>
-            </li>`
-          : ""}
+                  <fa-icon
+                    title="Hide"
+                    .svg="${fasAngleLeft}"
+                    aria-hidden="true"
+                  ></fa-icon>
+                  <span class="nav-hover" aria-hidden="true">Hide</span>
+                  <span class="is-sr-only">Hide Sidebar</span>
+                </a>
+              </li>`
+            : ""
+        }
+        ${
+          this.hasStory
+            ? html` <li
+                class="${this.tabData.view === "story" ? "is-active" : ""}"
+              >
+                <a
+                  @click="${this.onTabClick}"
+                  href="#story"
+                  class="is-size-6"
+                  aria-label="Story"
+                  aria-current="${ifDefined(
+                    this.tabData.view === "story" ? "location" : undefined,
+                  )}"
+                >
+                  <span class="icon"
+                    ><fa-icon
+                      .svg="${fasBook}"
+                      aria-hidden="true"
+                      title="Story"
+                    ></fa-icon
+                  ></span>
+                  <span
+                    class="tab-label ${isSidebar ? "is-hidden" : ""}"
+                    title="Story"
+                    >Story</span
+                  >
+                </a>
+              </li>`
+            : ""
+        }
 
         <li class="${this.tabData.view === "pages" ? "is-active" : ""}">
           <a
@@ -1055,7 +1059,7 @@ class Item extends LitElement {
               ></fa-icon
             ></span>
             <span
-              class="tab-label ${isSidebar ? "is-hidden" : ""}"
+              class="tab-label"
               title="Pages"
               >Pages</span
             >
@@ -1076,34 +1080,36 @@ class Item extends LitElement {
               ><fa-icon
                 .svg="${farResources}"
                 aria-hidden="true"
-                title="URLs"
+                title="Resources"
               ></fa-icon
             ></span>
-            <span class="tab-label ${isSidebar ? "is-hidden" : ""}" title="URLs"
-              >URLs</span
+            <span class="tab-label title="Resources"
+              >Resources</span
             >
           </a>
         </li>
 
-        ${isSidebar
-          ? html` <li class="sidebar-nav right">
-              <a
-                role="button"
-                href="#"
-                @click="${this.onFullPageView}"
-                @keyup="${clickOnSpacebarPress}"
-                class="is-marginless is-size-6 is-paddingless"
-              >
-                <span class="nav-hover" aria-hidden="true">Expand</span>
-                <span class="is-sr-only">Expand Sidebar to Full View</span>
-                <fa-icon
-                  title="Expand"
-                  .svg="${fasAngleRight}"
-                  aria-hidden="true"
-                ></fa-icon>
-              </a>
-            </li>`
-          : ""}
+        ${
+          isSidebar
+            ? html` <li class="sidebar-nav right">
+                <a
+                  role="button"
+                  href="#"
+                  @click="${this.onFullPageView}"
+                  @keyup="${clickOnSpacebarPress}"
+                  class="is-marginless is-size-6 is-paddingless"
+                >
+                  <span class="nav-hover" aria-hidden="true">Expand</span>
+                  <span class="is-sr-only">Expand Sidebar to Full View</span>
+                  <fa-icon
+                    title="Expand"
+                    .svg="${fasAngleRight}"
+                    aria-hidden="true"
+                  ></fa-icon>
+                </a>
+              </li>`
+            : ""
+        }
       </ul>
     </nav>`;
   }

--- a/src/item.ts
+++ b/src/item.ts
@@ -1413,7 +1413,7 @@ class Item extends LitElement {
                   : html``}
                 ${dateStr
                   ? html` <hr class="dropdown-divider is-hidden-desktop" />
-                      <div class="dropdown-item info is-hidden-desktop">
+                      <div class="dropdown-item info is-hidden-tablet">
                         <span class="menu-head">Capture Date</span>${dateStr}
                       </div>`
                   : ""}

--- a/src/item.ts
+++ b/src/item.ts
@@ -1127,86 +1127,6 @@ class Item extends LitElement {
       >
       <nav class="replay-bar" aria-label="replay">
         <div class="field has-addons">
-          <a
-            href="#"
-            role="button"
-            class="button narrow is-borderless is-hidden-touch"
-            id="fullscreen"
-            @click="${this.onFullscreenToggle}"
-            @keyup="${clickOnSpacebarPress}"
-            title="${this.isFullscreen ? "Exit Full Screen" : "Full Screen"}"
-            aria-label="${this.isFullscreen ? "Exit Fullscreen" : "Fullscreen"}"
-          >
-            <span class="icon is-small">
-              <fa-icon
-                size="1.0em"
-                class="has-text-grey"
-                aria-hidden="true"
-                .svg="${this.isFullscreen ? fasUnfullscreen : fasFullscreen}"
-              ></fa-icon>
-            </span>
-          </a>
-          <a
-            href="#"
-            role="button"
-            class="button narrow is-borderless is-hidden-mobile"
-            @click="${this.onGoBack}"
-            @keyup="${clickOnSpacebarPress}"
-            title="Back"
-            aria-label="Back"
-          >
-            <span class="icon is-small">
-              <fa-icon
-                size="1.0em"
-                class="has-text-grey"
-                aria-hidden="true"
-                .svg="${fasLeft}"
-              ></fa-icon>
-            </span>
-          </a>
-          <a
-            href="#"
-            role="button"
-            class="button narrow is-borderless is-hidden-mobile"
-            @click="${this.onGoForward}"
-            @keyup="${clickOnSpacebarPress}"
-            title="Forward"
-            aria-label="Forward"
-          >
-            <span class="icon is-small">
-              <fa-icon
-                size="1.0em"
-                class="has-text-grey"
-                aria-hidden="true"
-                .svg="${fasRight}"
-              ></fa-icon>
-            </span>
-          </a>
-          <a
-            href="#"
-            role="button"
-            class="button narrow is-borderless ${this.isLoading
-              ? "is-loading"
-              : "is-hidden-mobile"}"
-            id="refresh"
-            @click="${this.onRefresh}"
-            @keyup="${clickOnSpacebarPress}"
-            title="Reload"
-            aria-label="Reload"
-          >
-            <span class="icon is-small">
-              ${!this.isLoading
-                ? html`
-                    <fa-icon
-                      size="1.0em"
-                      class="has-text-grey"
-                      aria-hidden="true"
-                      .svg="${fasRefresh}"
-                    ></fa-icon>
-                  `
-                : ""}
-            </span>
-          </a>
           ${this.browsable
             ? html` <a
                 href="#"
@@ -1231,6 +1151,67 @@ class Item extends LitElement {
                 </span>
               </a>`
             : ""}
+          <a
+            href="#"
+            role="button"
+            class="button narrow is-borderless"
+            @click="${this.onGoBack}"
+            @keyup="${clickOnSpacebarPress}"
+            title="Back"
+            aria-label="Back"
+          >
+            <span class="icon is-small">
+              <fa-icon
+                size="1.0em"
+                class="has-text-grey"
+                aria-hidden="true"
+                .svg="${fasLeft}"
+              ></fa-icon>
+            </span>
+          </a>
+          <a
+            href="#"
+            role="button"
+            class="button narrow is-borderless"
+            @click="${this.onGoForward}"
+            @keyup="${clickOnSpacebarPress}"
+            title="Forward"
+            aria-label="Forward"
+          >
+            <span class="icon is-small">
+              <fa-icon
+                size="1.0em"
+                class="has-text-grey"
+                aria-hidden="true"
+                .svg="${fasRight}"
+              ></fa-icon>
+            </span>
+          </a>
+          <a
+            href="#"
+            role="button"
+            class="button narrow is-borderless ${this.isLoading
+              ? "is-loading"
+              : ""}"
+            id="refresh"
+            @click="${this.onRefresh}"
+            @keyup="${clickOnSpacebarPress}"
+            title="Reload"
+            aria-label="Reload"
+          >
+            <span class="icon is-small">
+              ${!this.isLoading
+                ? html`
+                    <fa-icon
+                      size="1.0em"
+                      class="has-text-grey"
+                      aria-hidden="true"
+                      .svg="${fasRefresh}"
+                    ></fa-icon>
+                  `
+                : ""}
+            </span>
+          </a>
           ${this.renderExtraToolbar()}
           <form @submit="${this.onSubmit}">
             <div
@@ -1258,6 +1239,27 @@ class Item extends LitElement {
             class="dropdown is-right ${this.menuActive ? "is-active" : ""}"
             @click="${() => (this.menuActive = false)}"
           >
+            <a
+              href="#"
+              role="button"
+              class="button narrow is-borderless is-hidden-touch"
+              id="fullscreen"
+              @click="${this.onFullscreenToggle}"
+              @keyup="${clickOnSpacebarPress}"
+              title="${this.isFullscreen ? "Exit Full Screen" : "Full Screen"}"
+              aria-label="${this.isFullscreen
+                ? "Exit Fullscreen"
+                : "Fullscreen"}"
+            >
+              <span class="icon is-small">
+                <fa-icon
+                  size="1.0em"
+                  class="has-text-grey"
+                  aria-hidden="true"
+                  .svg="${this.isFullscreen ? fasUnfullscreen : fasFullscreen}"
+                ></fa-icon>
+              </span>
+            </a>
             <div class="dropdown-trigger">
               <button
                 class="button is-borderless"
@@ -1297,57 +1299,6 @@ class Item extends LitElement {
                     ></fa-icon>
                   </span>
                   <span>Full Screen</span>
-                </a>
-                <a
-                  href="#"
-                  role="button"
-                  class="dropdown-item is-hidden-tablet"
-                  @click="${this.onGoBack}"
-                  @keyup="${clickOnSpacebarPress}"
-                >
-                  <span class="icon is-small">
-                    <fa-icon
-                      size="1.0em"
-                      class="has-text-grey"
-                      aria-hidden="true"
-                      .svg="${fasLeft}"
-                    ></fa-icon>
-                  </span>
-                  <span>Back</span>
-                </a>
-                <a
-                  href="#"
-                  role="button"
-                  class="dropdown-item is-hidden-tablet"
-                  @click="${this.onGoForward}"
-                  @keyup="${clickOnSpacebarPress}"
-                >
-                  <span class="icon is-small">
-                    <fa-icon
-                      size="1.0em"
-                      class="has-text-grey"
-                      aria-hidden="true"
-                      .svg="${fasRight}"
-                    ></fa-icon>
-                  </span>
-                  <span>Forward</span>
-                </a>
-                <a
-                  href="#"
-                  role="button"
-                  class="dropdown-item is-hidden-tablet"
-                  @click="${this.onRefresh}"
-                  @keyup="${clickOnSpacebarPress}"
-                >
-                  <span class="icon is-small">
-                    <fa-icon
-                      size="1.0em"
-                      class="has-text-grey"
-                      aria-hidden="true"
-                      .svg="${fasRefresh}"
-                    ></fa-icon>
-                  </span>
-                  <span>Reload</span>
                 </a>
                 ${this.browsable
                   ? html` <a

--- a/src/item.ts
+++ b/src/item.ts
@@ -989,57 +989,53 @@ class Item extends LitElement {
       aria-label="tabs"
     >
       <ul>
-        ${
-          isSidebar
-            ? html` <li class="sidebar-nav left">
-                <a
-                  role="button"
-                  href="#"
-                  @click="${this.onHideSidebar}"
-                  @keyup="${clickOnSpacebarPress}"
-                  class="is-marginless is-size-6 is-paddingless"
-                >
-                  <fa-icon
-                    title="Hide"
-                    .svg="${fasAngleLeft}"
-                    aria-hidden="true"
-                  ></fa-icon>
-                  <span class="nav-hover" aria-hidden="true">Hide</span>
-                  <span class="is-sr-only">Hide Sidebar</span>
-                </a>
-              </li>`
-            : ""
-        }
-        ${
-          this.hasStory
-            ? html` <li
-                class="${this.tabData.view === "story" ? "is-active" : ""}"
+        ${isSidebar
+          ? html` <li class="sidebar-nav left">
+              <a
+                role="button"
+                href="#"
+                @click="${this.onHideSidebar}"
+                @keyup="${clickOnSpacebarPress}"
+                class="is-marginless is-size-6 is-paddingless"
               >
-                <a
-                  @click="${this.onTabClick}"
-                  href="#story"
-                  class="is-size-6"
-                  aria-label="Story"
-                  aria-current="${ifDefined(
-                    this.tabData.view === "story" ? "location" : undefined,
-                  )}"
-                >
-                  <span class="icon"
-                    ><fa-icon
-                      .svg="${fasBook}"
-                      aria-hidden="true"
-                      title="Story"
-                    ></fa-icon
-                  ></span>
-                  <span
-                    class="tab-label ${isSidebar ? "is-hidden" : ""}"
+                <fa-icon
+                  title="Hide"
+                  .svg="${fasAngleLeft}"
+                  aria-hidden="true"
+                ></fa-icon>
+                <span class="nav-hover" aria-hidden="true">Hide</span>
+                <span class="is-sr-only">Hide Sidebar</span>
+              </a>
+            </li>`
+          : ""}
+        ${this.hasStory
+          ? html` <li
+              class="${this.tabData.view === "story" ? "is-active" : ""}"
+            >
+              <a
+                @click="${this.onTabClick}"
+                href="#story"
+                class="is-size-6"
+                aria-label="Story"
+                aria-current="${ifDefined(
+                  this.tabData.view === "story" ? "location" : undefined,
+                )}"
+              >
+                <span class="icon"
+                  ><fa-icon
+                    .svg="${fasBook}"
+                    aria-hidden="true"
                     title="Story"
-                    >Story</span
-                  >
-                </a>
-              </li>`
-            : ""
-        }
+                  ></fa-icon
+                ></span>
+                <span
+                  class="tab-label ${isSidebar ? "is-hidden" : ""}"
+                  title="Story"
+                  >Story</span
+                >
+              </a>
+            </li>`
+          : ""}
 
         <li class="${this.tabData.view === "pages" ? "is-active" : ""}">
           <a
@@ -1058,11 +1054,7 @@ class Item extends LitElement {
                 title="Pages"
               ></fa-icon
             ></span>
-            <span
-              class="tab-label"
-              title="Pages"
-              >Pages</span
-            >
+            <span class="tab-label" title="Pages">Pages</span>
           </a>
         </li>
 
@@ -1083,33 +1075,29 @@ class Item extends LitElement {
                 title="Resources"
               ></fa-icon
             ></span>
-            <span class="tab-label title="Resources"
-              >Resources</span
-            >
+            <span class="tab-label" title="Resources">Resources</span>
           </a>
         </li>
 
-        ${
-          isSidebar
-            ? html` <li class="sidebar-nav right">
-                <a
-                  role="button"
-                  href="#"
-                  @click="${this.onFullPageView}"
-                  @keyup="${clickOnSpacebarPress}"
-                  class="is-marginless is-size-6 is-paddingless"
-                >
-                  <span class="nav-hover" aria-hidden="true">Expand</span>
-                  <span class="is-sr-only">Expand Sidebar to Full View</span>
-                  <fa-icon
-                    title="Expand"
-                    .svg="${fasAngleRight}"
-                    aria-hidden="true"
-                  ></fa-icon>
-                </a>
-              </li>`
-            : ""
-        }
+        ${isSidebar
+          ? html` <li class="sidebar-nav right">
+              <a
+                role="button"
+                href="#"
+                @click="${this.onFullPageView}"
+                @keyup="${clickOnSpacebarPress}"
+                class="is-marginless is-size-6 is-paddingless"
+              >
+                <span class="nav-hover" aria-hidden="true">Expand</span>
+                <span class="is-sr-only">Expand Sidebar to Full View</span>
+                <fa-icon
+                  title="Expand"
+                  .svg="${fasAngleRight}"
+                  aria-hidden="true"
+                ></fa-icon>
+              </a>
+            </li>`
+          : ""}
       </ul>
     </nav>`;
   }

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -612,7 +612,7 @@ class Pages extends LitElement {
               @input="${this.onChangeQuery}"
               .value="${this.query}"
               type="text"
-              placeholder="Search by Page URL, Title or Text"
+              placeholder="Search by Page URL, Title, or Text"
             />
             <span class="icon is-left"
               ><fa-icon .svg="${fasSearch}" aria-hidden="true"></fa-icon

--- a/src/url-resources.ts
+++ b/src/url-resources.ts
@@ -63,7 +63,7 @@ class URLResources extends LitElement {
       },
       {
         key: "mime",
-        name: "Mime Type",
+        name: "Media Type",
       },
       {
         key: "status",
@@ -504,7 +504,7 @@ class URLResources extends LitElement {
                     ? "desc"
                     : "asc"
                   : ""}"
-                >Mime Type</a
+                >Media Type</a
               >
             </th>
             <th scope="col" class="column col-status is-1 is-hidden-mobile">
@@ -552,7 +552,7 @@ class URLResources extends LitElement {
                       ${new Date(result.date).toLocaleString()}
                     </td>
                     <td class="column col-mime is-3">
-                      <p class="minihead is-hidden-tablet">Mime Type</p>
+                      <p class="minihead is-hidden-tablet">Media Type</p>
                       ${result.mime}
                     </td>
                     <td class="column col-status is-1">


### PR DESCRIPTION
Partially addresses #237

### Context

Updates originally from #292, now split out into a discrete PR from branding updates.

### Changes
- Unhides the load button on smaller screen sizes
  - There's no way to actually load new web archives when this is hidden
- Minor text updates
  - Renames MIME Type to Media Type
  - Punctuation fixes
- Reorder main application controls (#237)
  - Group navigation related controls together on the left side
  - Move full screen to the right side
  - Enable navigation controls on mobile
- Renames URLs tab to Resources
  - Now that we have more space (because we moved the archived item info to a dialog), we can make these titles visible when space is available to do so!
  - This is now in-line with the docs (both current and new!)

### Screenshots

**Desktop**
<img width="1100" alt="Screenshot 2024-04-05 at 3 47 13 PM" src="https://github.com/webrecorder/replayweb.page/assets/5672810/cc1c3a98-ab05-4a30-b8cf-8da106e59861">

**Mobile**
<img width="448" alt="Screenshot 2024-04-05 at 3 47 23 PM" src="https://github.com/webrecorder/replayweb.page/assets/5672810/0ed1c94e-e9c9-47b6-8831-1926412e2486">