### PR TITLE
Adds sl-copy-button fontawesome icons

### DIFF
--- a/src/components/labeled-field.ts
+++ b/src/components/labeled-field.ts
@@ -4,8 +4,24 @@ import { customElement, property } from "lit/decorators.js";
 import { wrapCss } from "./../misc";
 import faClone from "@fortawesome/fontawesome-free/svgs/regular/clone.svg";
 import faCheck from "@fortawesome/fontawesome-free/svgs/solid/check.svg";
+import faX from "@fortawesome/fontawesome-free/svgs/solid/times.svg";
 
 import "@shoelace-style/shoelace/dist/components/copy-button/copy-button.js";
+
+import { registerIconLibrary } from "@shoelace-style/shoelace/dist/utilities/icon-library.js";
+
+import systemLibrary from "@shoelace-style/shoelace/dist/components/icon/library.system";
+
+// disable system library to prevent loading of unused data: URLs, as we're not using
+// <sl-icon>
+registerIconLibrary("system", {
+  resolver: (name) => {
+    if (name === "x-lg") {
+      return systemLibrary.resolver(name);
+    }
+    return "";
+  },
+});
 
 @customElement("wr-labeled-field")
 class LabeledField extends LitElement {
@@ -60,6 +76,11 @@ class LabeledField extends LitElement {
               <fa-icon
                 slot="success-icon"
                 .svg=${faCheck}
+                aria-hidden="true"
+              ></fa-icon>
+              <fa-icon
+                slot="error-icon"
+                .svg=${faX}
                 aria-hidden="true"
               ></fa-icon>
             </sl-copy-button>`

--- a/src/components/labeled-field.ts
+++ b/src/components/labeled-field.ts
@@ -12,8 +12,8 @@ import { registerIconLibrary } from "@shoelace-style/shoelace/dist/utilities/ico
 
 import systemLibrary from "@shoelace-style/shoelace/dist/components/icon/library.system";
 
-// disable system library to prevent loading of unused data: URLs, as we're not using
-// <sl-icon>
+// disable system library to prevent loading of unused data: URLs
+// allow only "x-lg" as it is needed for sl-dialog
 registerIconLibrary("system", {
   resolver: (name) => {
     if (name === "x-lg") {

--- a/src/components/labeled-field.ts
+++ b/src/components/labeled-field.ts
@@ -2,6 +2,9 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import { wrapCss } from "./../misc";
+import faClone from "@fortawesome/fontawesome-free/svgs/regular/clone.svg";
+import faCheck from "@fortawesome/fontawesome-free/svgs/solid/check.svg";
+
 import "@shoelace-style/shoelace/dist/components/copy-button/copy-button.js";
 
 @customElement("wr-labeled-field")
@@ -48,7 +51,18 @@ class LabeledField extends LitElement {
       <div class="col-content">
         <slot></slot>
         ${this.copy
-          ? html` <sl-copy-button .value=${this.copy || ""}></sl-copy-button>`
+          ? html` <sl-copy-button .value=${this.copy || ""}>
+              <fa-icon
+                slot="copy-icon"
+                .svg=${faClone}
+                aria-hidden="true"
+              ></fa-icon>
+              <fa-icon
+                slot="success-icon"
+                .svg=${faCheck}
+                aria-hidden="true"
+              ></fa-icon>
+            </sl-copy-button>`
           : nothing}
       </div>`;
   }

--- a/src/item-info.ts
+++ b/src/item-info.ts
@@ -181,7 +181,7 @@ class ItemInfo extends LitElement {
               ${certFingerprintUrl
                 ? html`<span
                     ><a target="_blank" href="${certFingerprintUrl}"
-                      >View Certificate</a
+                      >&nbsp;View Certificate</a
                     ></span
                   >`
                 : nothing}

--- a/src/item.ts
+++ b/src/item.ts
@@ -32,6 +32,7 @@ import {
   getDateFromTS,
 } from "./pageutils";
 
+import fasTriangleExclamation from "@fortawesome/fontawesome-free/svgs/solid/exclamation-triangle.svg";
 import fasBook from "@fortawesome/fontawesome-free/svgs/solid/book.svg";
 
 import fasDownload from "@fortawesome/fontawesome-free/svgs/solid/download.svg";
@@ -1478,7 +1479,11 @@ class Item extends LitElement {
   renderItemInfo() {
     if (!this.itemInfo)
       return html`<sl-alert open variant="warning">
-        <sl-icon slot="icon" name="exclamation-triangle"></sl-icon>
+        <fa-icon
+          slot="icon"
+          .svg=${fasTriangleExclamation}
+          aria-hidden="true"
+        ></fa-icon>
         <strong>Archive info is not available</strong><br />
         Please reload and try again.
       </sl-alert>`;


### PR DESCRIPTION
- Changes `sl-copy-button` icons to use fontawesome equivalents so they fit in with everything else in ReplayWebpage
- Adds missing whitespace

### Screenshots

<img width="528" alt="Screenshot_2024-04-08_at_10 14 29_PM" src="https://github.com/webrecorder/replayweb.page/assets/5672810/8a36202c-455c-4eae-a5eb-1f1fb366619f">