### PR TITLE
Electron Fix for 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,14 +68,14 @@
     "/assets",
     "/dist",
     "/src",
-    "/ruffle",
-    "sw.js",
-    "ui.js",
-    "index.html"
+    "site/ruffle",
+    "site/sw.js",
+    "site/ui.js",
+    "site/index.html"
   ],
   "scripts": {
-    "build": "webpack --mode production && cp dist/ui.js site/ui.js",
-    "build-dev": "webpack --mode development && cp dist/ui.js site/ui.js",
+    "build": "webpack --mode production",
+    "build-dev": "webpack --mode development",
     "build-docs": "yarn run build && cd mkdocs && mkdocs build",
     "start-prod": "cd site && http-server -p 9990 --cors",
     "start-dev": "webpack serve --mode development",
@@ -106,15 +106,11 @@
       "dist/*.js",
       "dist/prebuilds/${platform}-${arch}/*",
       "dist/build/*",
-      "ui.js",
-      "sw.js",
-      "*.html",
-      "ruffle",
-      "webmanifest.json",
-      {
-        "from": "_site/assets",
-        "to": "assets"
-      }
+      "site/ui.js",
+      "site/sw.js",
+      "site/index.html",
+      "site/ruffle",
+      "site/webmanifest.json"
     ],
     "dmg": {
       "title": "ReplayWeb.page"

--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -5,7 +5,7 @@ import path from "path";
 
 // ============================================================================
 const replayApp = new ElectronReplayApp({
-  staticPath: path.join(__dirname, "../"),
+  staticPath: path.join(__dirname, "../site"),
   profileName: "replaywebpage",
 });
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,10 +75,6 @@ const electronMainConfig = (/*env, argv*/) => {
         patterns: [
           // { from: "node_modules/classic-level/prebuilds/", to: "prebuilds" },
           { from: "build/extra_prebuilds/", to: "prebuilds" },
-          {
-            from: path.resolve(__dirname, "src/assets/favicons"),
-            to: path.resolve(__dirname, "dist/favicons"),
-          },
         ],
       }),
     ],
@@ -140,7 +136,7 @@ const browserConfig = (/*env, argv*/) => {
 
     output: {
       path: path.join(__dirname),
-      filename: "dist/[name].js",
+      filename: "site/[name].js",
       libraryTarget: "self",
       globalObject: "self",
       publicPath: "/",


### PR DESCRIPTION
build UI.js to site/ directly (build electron to dist/)
no longer need to copy favicons
load site assets directly from site/