### PR TITLE
Add opengraph site name to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <link rel="manifest" href="/webmanifest.json" />
     <title>ReplayWeb.page</title>
+    <meta property="og:site_name" content="ReplayWeb.page" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <script src="./ui.js"></script>
     <link rel="icon" href="/favicons/favicon.ico" sizes="32x32" />


### PR DESCRIPTION
Hopefully fixes ReplayWeb.page's name not appearing in Google search results properly because they appear to remove `.domain` from webpage titles.

<img width="1697" alt="Screenshot 2024-05-22 at 11 45 35 PM" src="https://github.com/webrecorder/replayweb.page/assets/5672810/721ebd58-1d2d-4cb4-8b6a-5280cc9bf768">

This notably doesn't seem to happen with ArchiveWeb.page... Maybe because the title attribute is all lower case?  Google remains a mystery.
<img width="1555" alt="Screenshot 2024-05-22 at 11 47 46 PM" src="https://github.com/webrecorder/replayweb.page/assets/5672810/f8857030-6ab9-4143-b20d-b1c30252ab3d">
