### PR TITLE
Resource search remove auto-added http prefix

### DIFF
--- a/src/url-resources.ts
+++ b/src/url-resources.ts
@@ -163,13 +163,13 @@ class URLResources extends LitElement {
     }
 
     this.loading = true;
-    let url = this.urlSearchType !== "contains" ? this.query : "";
+    const url = this.urlSearchType !== "contains" ? this.query : "";
     const prefix = url && this.urlSearchType === "prefix" ? 1 : 0;
 
-    // optimization: if not starting with http, likely won't have a match here, so just add https://
-    if (url && !url.startsWith("http")) {
-      url = "https://" + url;
-    }
+    // optimization: if not starting with http or urn:, likely won't have a match here, so just add https://
+    // if (url && !url.startsWith("http") && !url.startsWith("urn:")) {
+    //   url = "https://" + url;
+    // }
 
     const mime = this.currMime;
 

--- a/src/url-resources.ts
+++ b/src/url-resources.ts
@@ -166,11 +166,6 @@ class URLResources extends LitElement {
     const url = this.urlSearchType !== "contains" ? this.query : "";
     const prefix = url && this.urlSearchType === "prefix" ? 1 : 0;
 
-    // optimization: if not starting with http or urn:, likely won't have a match here, so just add https://
-    // if (url && !url.startsWith("http") && !url.startsWith("urn:")) {
-    //   url = "https://" + url;
-    // }
-
     const mime = this.currMime;
 
     const params = new URLSearchParams({

--- a/src/url-resources.ts
+++ b/src/url-resources.ts
@@ -112,7 +112,7 @@ class URLResources extends LitElement {
   firstUpdated() {
     //this.doLoadResources();
     if (this.urlSearchType === "") {
-      this.urlSearchType = "prefix";
+      this.urlSearchType = "contains";
     }
   }
 


### PR DESCRIPTION
remove previous optimization that auto-added 'https://' prefix to search queries, which resulted in 'urn:' resources not being searchable.
also caused unintuitive behavior, where 'ht' would show no results while 'http' would, now fixed. Results in more predictable search results in the end.