### PR TITLE
Configure package exports explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,18 @@
   "homepage": "https://replayweb.page/",
   "author": "Webrecorder Software",
   "license": "AGPL-3.0-or-later",
-  "main": "ui.js",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "default": "./ui.js"
+    },
+    "./misc": {
+      "types": "./dist/types/misc.d.ts",
+      "default": "./dist/misc.js"
+    },
+    "./src/electron-*": "./src/electron-*.ts",
+    "./index.html": "./index.html"
+  },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@shoelace-style/shoelace": "~2.15.1",

--- a/src/components/labeled-field.ts
+++ b/src/components/labeled-field.ts
@@ -8,7 +8,7 @@ import faX from "@fortawesome/fontawesome-free/svgs/solid/times.svg";
 
 import { registerIconLibrary } from "@shoelace-style/shoelace/dist/utilities/icon-library.js";
 
-import systemLibrary from "@shoelace-style/shoelace/dist/components/icon/library.system";
+import systemLibrary from "@shoelace-style/shoelace/dist/components/icon/library.system.js";
 
 // disable system library to prevent loading of unused data: URLs
 // allow only "x-lg" as it is needed for sl-dialog

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "./dist/",
     "module": "esnext",
     "target": "es6",
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "strict": true,
     "declaration": true,


### PR DESCRIPTION
Closes #337
Blocks https://github.com/webrecorder/archiveweb.page/issues/198

Adds a dedicated `misc` export, as well as explicitly exporting the `electron-*` files and the `index.html` file. This restricts imports to only these files, and allows us to not have to exactly match webpack configs between RWP and AWP.

