### PR TITLE
Bump macos version to 13 and node to 20 in CI

### DIFF
--- a/.github/workflows/buildapp.yaml
+++ b/.github/workflows/buildapp.yaml
@@ -8,10 +8,10 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-12, ubuntu-latest]
+        os: [macos-13, ubuntu-latest]
         platform: [windows, linux]
         exclude:
-          - os: macos-12
+          - os: macos-13
             platform: windows
 
     steps:
@@ -21,7 +21,8 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v2
         with:
-          node-version: '18'
+          node-version: '20'
+          cache: 'yarn'
 
       - name: Cache Dirs
         uses: actions/cache@v2
@@ -105,4 +106,4 @@ jobs:
                 yarn --link-duplicates --pure-lockfile --ignore-engines install
                 yarn run $YARN_BUILD_CMD
               fi
-               
+

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           cache: 'yarn'
 
       - name: Yarn Install

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           cache: 'yarn'
 
       - name: Yarn Install

--- a/.github/workflows/npm-release.yaml
+++ b/.github/workflows/npm-release.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version: 20
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
 


### PR DESCRIPTION
macOS builders are failing with major version 12 because it's deprecated now https://github.com/actions/runner-images/issues/10721