### PR TITLE
Support for dynamic page loading for Multi-WACZs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "replaywebpage",
   "productName": "ReplayWeb.page",
-  "version": "2.2.5",
+  "version": "2.3.0-beta.0",
   "description": "Serverless Web Archive Replay",
   "repository": "https://github.com/webrecorder/replayweb.page",
   "homepage": "https://replayweb.page/",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@shoelace-style/shoelace": "~2.15.1",
-    "@webrecorder/wabac": "^2.20.8",
+    "@webrecorder/wabac": "^2.21.0",
     "bulma": "^0.9.3",
     "electron-log": "^4.4.1",
     "electron-updater": "^6.3.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "replaywebpage",
   "productName": "ReplayWeb.page",
-  "version": "2.3.0-beta.0",
+  "version": "2.3.0",
   "description": "Serverless Web Archive Replay",
   "repository": "https://github.com/webrecorder/replayweb.page",
   "homepage": "https://replayweb.page/",

--- a/src/item.ts
+++ b/src/item.ts
@@ -85,6 +85,7 @@ export type EmbedReplayData = {
   ts?: string;
   title?: string;
   query?: string;
+  waczhash?: string;
 };
 
 export type EmbedReplayEvent = EmbedReplayData & {
@@ -976,6 +977,7 @@ class Item extends LitElement {
                   sourceUrl="${this.sourceUrl || ""}"
                   url="${this.tabData.url || ""}"
                   ts="${this.tabData.ts || ""}"
+                  waczhash="${this.tabData.waczhash || ""}"
                   @coll-tab-nav="${this.onItemTabNav}"
                   id="replay"
                   @replay-loading="${this.onReplayLoading}"

--- a/src/item.ts
+++ b/src/item.ts
@@ -230,16 +230,6 @@ class Item extends LitElement {
 
       this.observer.observe(this);
     }
-
-    if (this.embed) {
-      window.addEventListener("message", (event: MessageEvent) => {
-        if (event.source === window.parent) {
-          if (event.data.type === "fullReload") {
-            void this.deleteFully(true);
-          }
-        }
-      });
-    }
   }
 
   async runUpdateLoop() {

--- a/src/pageentry.ts
+++ b/src/pageentry.ts
@@ -245,6 +245,7 @@ class PageEntry extends LitElement {
                     "pages",
                     this.page!.url,
                     this.page!.timestamp!,
+                    this.page!.waczhash,
                   )}"
                 >
                   <p class="is-size-6 has-text-weight-bold has-text-link text">
@@ -298,6 +299,12 @@ class PageEntry extends LitElement {
     `;
   }
 
+  private getReplayPrefix() {
+    const waczhash = this.page!.waczhash ? `:${this.page!.waczhash}/` : "";
+    const ts = this.page!.timestamp || "";
+    return this.replayPrefix + "/" + waczhash + ts + "id_";
+  }
+
   private renderPageIcon() {
     if (!this.thumbnailValid) {
       return this.renderFavicon();
@@ -305,9 +312,7 @@ class PageEntry extends LitElement {
     return html`<img
       class="thumbnail"
       @error=${() => (this.thumbnailValid = false)}
-      src=${`${this.replayPrefix}/${this.page!.timestamp}id_/urn:thumbnail:${
-        this.page!.url
-      }`}
+      src=${`${this.getReplayPrefix()}/urn:thumbnail:${this.page!.url}`}
       loading="lazy"
     />`;
   }
@@ -319,9 +324,7 @@ class PageEntry extends LitElement {
     return html`<img
       class="favicon"
       @error=${() => (this.iconValid = false)}
-      src=${`${this.replayPrefix}/${this.page!.timestamp}id_/${
-        this.page!.favIconUrl
-      }`}
+      src=${`${this.getReplayPrefix()}/${this.page!.favIconUrl}`}
       loading="lazy"
     />`;
   }
@@ -377,6 +380,7 @@ class PageEntry extends LitElement {
     const data = {
       url: this.page!.url,
       ts: this.page!.timestamp,
+      waczhash: this.page!.waczhash,
     };
     this.sendChangeEvent(data, reload);
     return false;

--- a/src/pageentry.ts
+++ b/src/pageentry.ts
@@ -5,7 +5,7 @@ import { property, state } from "lit/decorators.js";
 
 import "keyword-mark-element/lib/keyword-mark.js";
 
-import { getReplayLink } from "./pageutils";
+import { getPageDateTS, getReplayLink } from "./pageutils";
 
 import { wrapCss } from "./misc";
 import type { URLResource } from "./types";
@@ -192,7 +192,7 @@ class PageEntry extends LitElement {
 
   render() {
     const p = this.page!;
-    const date = this.page!.date;
+    const { date } = getPageDateTS(p);
 
     const hasSize = typeof p.size === "number";
 

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -20,6 +20,8 @@ import type { PageEntry } from "./pageentry";
 import type { Id, Index } from "flexsearch";
 import type { ItemType, URLResource } from "./types";
 
+const DYNAMIC_PAGE_SIZE = 25;
+
 // ===========================================================================
 class Pages extends LitElement {
   @property({ type: Array })
@@ -105,6 +107,15 @@ class Pages extends LitElement {
 
   @property({ type: Boolean })
   dynamicPagesQuery = false;
+
+  @property({ type: Number })
+  totalPages = 0;
+
+  @property({ type: Number })
+  dynamicPageCount = 1;
+
+  @property({ type: Boolean })
+  skipScrollMore = false;
 
   private _ival: number | undefined;
 
@@ -221,14 +232,11 @@ class Pages extends LitElement {
       this.filteredPages = [...this.collInfo!.pages];
     }
 
+    this.totalPages = this.filteredPages.length;
+
     if (this.query && this.dynamicPagesQuery) {
-      const resp = await fetch(
-        `${this.collInfo!.apiPrefix}/pages?q=${this.query}`,
-      );
-      const json = await resp.json();
-      if (json.pages) {
-        this.addDynamicPages(json.pages);
-      }
+      this.dynamicPageCount = 1;
+      await this.addDynamicPages();
     }
 
     if (this.currList !== 0) {
@@ -251,8 +259,20 @@ class Pages extends LitElement {
     this.sendChangeEvent(data);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  addDynamicPages(pages: any[]) {
+  async addDynamicPages() {
+    const search = new URLSearchParams();
+    search.set("search", this.query);
+    search.set("page", this.dynamicPageCount + "");
+    search.set("pageSize", DYNAMIC_PAGE_SIZE + "");
+
+    const resp = await fetch(
+      `${this.collInfo!.apiPrefix}/pages?${search.toString()}`,
+    );
+    const json = await resp.json();
+    if (!json.pages) {
+      return;
+    }
+
     const knownPages = new Set();
     this.filteredPages.forEach((x) => knownPages.add(x.id));
 
@@ -267,7 +287,7 @@ class Pages extends LitElement {
       ts,
       favIconUrl,
       waczhash,
-    } of pages) {
+    } of json.pages) {
       if (knownPages.has(id)) {
         continue;
       }
@@ -297,6 +317,12 @@ class Pages extends LitElement {
 
     if (newPages.length) {
       this.filteredPages = [...this.filteredPages, ...newPages];
+    }
+
+    if (json.total) {
+      this.totalPages = json.total;
+    } else {
+      this.totalPages = this.filteredPages.length;
     }
   }
 
@@ -332,7 +358,7 @@ class Pages extends LitElement {
     );
 
     if (this.collInfo) {
-      this.dynamicPagesQuery = this.collInfo.hasPagesQuery || false;
+      this.dynamicPagesQuery = this.collInfo.canQueryPages || false;
     }
 
     return Promise.all(
@@ -959,7 +985,7 @@ class Pages extends LitElement {
           .sortDesc="${this.sortDesc}"
           .sortKeys="${Pages.sortKeys}"
           .data="${this.filteredPages}"
-          pageResults="100"
+          .pageResults="${this.dynamicPagesQuery ? this.totalPages : 100}"
           @sort-changed="${this.onSortChanged}"
           class="${this.filteredPages.length ? "" : "is-hidden"}"
         >
@@ -1130,6 +1156,8 @@ class Pages extends LitElement {
     this.sortedPages = event.detail.sortedData;
     this.sortKey = event.detail.sortKey;
     this.sortDesc = event.detail.sortDesc;
+
+    void this.updateComplete.then(() => (this.skipScrollMore = false));
   }
 
   // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
@@ -1250,21 +1278,11 @@ class Pages extends LitElement {
   }
 
   formatResults() {
-    // Default behavior: Count all available pages
-    if (!this.query) {
-      const length = this.filteredPages.length;
-      if (length === this.sortedPages.length) {
-        return `${length} Page${length !== 1 ? "s" : ""}`;
-      } else {
-        return `${this.sortedPages.length} of ${length} Pages Shown`;
-      }
-    }
-
-    // ... unless they were filtered
-    if (this.sortedPages.length === 1) {
-      return "1 Page";
+    const length = this.totalPages;
+    if (length === this.sortedPages.length) {
+      return `${length} Page${length !== 1 ? "s" : ""}`;
     } else {
-      return `${this.sortedPages.length} Pages`;
+      return `${this.sortedPages.length} of ${length} Pages Shown`;
     }
   }
 
@@ -1295,14 +1313,23 @@ class Pages extends LitElement {
   }
 
   // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
-  onScroll(event) {
+  async onScroll(event) {
     const element = event.currentTarget;
     const diff =
       element.scrollHeight - element.scrollTop - element.clientHeight;
-    if (diff < 40) {
+    if (diff < 40 && !this.skipScrollMore) {
+      this.skipScrollMore = true;
+      if (
+        this.dynamicPagesQuery &&
+        this.filteredPages.length < this.totalPages
+      ) {
+        this.dynamicPageCount += 1;
+        await this.addDynamicPages();
+      }
+
       const sorter = this.renderRoot.querySelector<Sorter>("wr-sorter");
       if (sorter) {
-        sorter.getMore();
+        sorter.getMore(DYNAMIC_PAGE_SIZE);
       }
     }
   }

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -237,9 +237,10 @@ class Pages extends LitElement {
     if (this.dynamicPagesQuery) {
       if (!this.query) {
         const seedPages = this.collInfo!.pages.filter((x) => x.isSeed);
-        this.filteredPages = this.showAllPages
-          ? [...this.collInfo!.pages]
-          : seedPages;
+        this.filteredPages =
+          this.showAllPages || !seedPages.length
+            ? [...this.collInfo!.pages]
+            : seedPages;
         this.hasExtraPages = seedPages.length !== this.collInfo!.pages.length;
       }
       this.dynamicPageCount = 1;

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -228,13 +228,20 @@ class Pages extends LitElement {
       );
     } else if (this.showAllPages && this.hasExtraPages) {
       this.filteredPages = [...this.textPages!];
-    } else {
+    } else if (!this.dynamicPagesQuery) {
       this.filteredPages = [...this.collInfo!.pages];
     }
 
     this.totalPages = this.filteredPages.length;
 
     if (this.dynamicPagesQuery) {
+      if (!this.query) {
+        const seedPages = this.collInfo!.pages.filter((x) => x.isSeed);
+        this.filteredPages = this.showAllPages
+          ? [...this.collInfo!.pages]
+          : seedPages;
+        this.hasExtraPages = seedPages.length !== this.collInfo!.pages.length;
+      }
       this.dynamicPageCount = 1;
       await this.addDynamicPages();
     }
@@ -289,8 +296,13 @@ class Pages extends LitElement {
       ts,
       favIconUrl,
       waczhash,
+      isSeed,
     } of json.pages) {
       if (knownPages.has(id)) {
+        continue;
+      }
+
+      if (!this.showAllPages && !isSeed) {
         continue;
       }
 
@@ -353,11 +365,13 @@ class Pages extends LitElement {
     this.flex = flex;
     this.textPages = pages;
 
-    this.hasExtraPages = Boolean(
-      this.textPages &&
-        this.collInfo?.pages &&
-        this.textPages.length > this.collInfo.pages.length,
-    );
+    if (!this.dynamicPagesQuery) {
+      this.hasExtraPages = Boolean(
+        this.textPages &&
+          this.collInfo?.pages &&
+          this.textPages.length > this.collInfo.pages.length,
+      );
+    }
 
     if (this.collInfo) {
       this.dynamicPagesQuery = this.collInfo.canQueryPages || false;

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -303,7 +303,7 @@ class Pages extends LitElement {
         continue;
       }
 
-      if (!this.showAllPages && !isSeed) {
+      if (!this.showAllPages && this.hasExtraPages && !this.query && !isSeed) {
         continue;
       }
 

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -234,7 +234,7 @@ class Pages extends LitElement {
 
     this.totalPages = this.filteredPages.length;
 
-    if (this.query && this.dynamicPagesQuery) {
+    if (this.dynamicPagesQuery) {
       this.dynamicPageCount = 1;
       await this.addDynamicPages();
     }
@@ -261,7 +261,9 @@ class Pages extends LitElement {
 
   async addDynamicPages() {
     const search = new URLSearchParams();
-    search.set("search", this.query);
+    if (this.query) {
+      search.set("search", this.query);
+    }
     search.set("page", this.dynamicPageCount + "");
     search.set("pageSize", DYNAMIC_PAGE_SIZE + "");
 

--- a/src/pageutils.ts
+++ b/src/pageutils.ts
@@ -69,11 +69,19 @@ function getTS(iso: string) {
 }
 
 // ===========================================================================
-function getReplayLink(view: string, url: string, ts: string) {
+function getReplayLink(
+  view: string,
+  url: string,
+  ts: string,
+  waczhash?: string,
+) {
   const params = new URLSearchParams();
   params.set("view", view);
   params.set("url", url);
   params.set("ts", ts);
+  if (waczhash) {
+    params.set("waczhash", waczhash);
+  }
   return "#" + params.toString();
 }
 

--- a/src/replay.ts
+++ b/src/replay.ts
@@ -20,6 +20,9 @@ class Replay extends LitElement {
   @property({ type: String })
   ts = "";
 
+  @property({ type: String })
+  waczhash = "";
+
   // actual replay url
   @property({ type: String })
   replayUrl = "";
@@ -97,7 +100,9 @@ class Replay extends LitElement {
   doSetIframeUrl() {
     this.iframeUrl =
       this.url && this.collInfo
-        ? `${this.collInfo.replayPrefix}/${this.ts || ""}mp_/${this.url}`
+        ? `${this.collInfo.replayPrefix}/${
+            this.waczhash ? `:${this.waczhash}/` : ""
+          }${this.ts || ""}mp_/${this.url}`
         : "";
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export type URLResource = {
   size: number;
   favIconUrl: string;
   text?: string;
+  waczhash?: string;
 };
 
 export type Page = URLResource;
@@ -49,6 +50,7 @@ export type ItemType = {
   ctime?: string;
   totalSize?: unknown;
   size?: number | string;
+  hasPagesQuery?: boolean;
 };
 
 export type FavIconEventDetail = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,9 @@ export type URLResource = {
   waczhash?: string;
 };
 
-export type Page = URLResource;
+export type Page = URLResource & {
+  isSeed?: boolean;
+};
 
 export type ItemType = {
   filename?: string;
@@ -44,7 +46,7 @@ export type ItemType = {
     software?: string;
   };
   onDemand?: boolean;
-  pages: URLResource[];
+  pages: Page[];
   curatedPages: (URLResource & { list: string })[];
   lists: URLResource[];
   ctime?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,7 +50,7 @@ export type ItemType = {
   ctime?: string;
   totalSize?: unknown;
   size?: number | string;
-  hasPagesQuery?: boolean;
+  canQueryPages?: boolean;
 };
 
 export type FavIconEventDetail = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,16 +1028,16 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-2.0.5.tgz#325db42395cd49fe6c14057f9a900e427df8810e"
   integrity sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==
 
-"@webrecorder/wabac@^2.20.8":
-  version "2.20.8"
-  resolved "https://registry.yarnpkg.com/@webrecorder/wabac/-/wabac-2.20.8.tgz#37dd14f4cf821f36ecdf5719d5f334bb3445290e"
-  integrity sha512-P6FxC17ZgPfwfp3HbdI9hkzMnqD5I3kBF0cMnue6m8wBVMCzcVGp9x43wT+pcq0zOv6ATGObxcmjJKCsDUus7A==
+"@webrecorder/wabac@^2.21.0":
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/@webrecorder/wabac/-/wabac-2.21.0.tgz#cc3483f15cb3f1502fdef89e1c9a4ee5709bcaec"
+  integrity sha512-28G3ci/m/qJXnLDoUP/Kt09PiTuORBZH0bw/JlKhPCeLL4IdYsODeXaImVwvTT12R9tV7Zp37w26jhkMfcur0w==
   dependencies:
     "@peculiar/asn1-ecc" "^2.3.4"
     "@peculiar/asn1-schema" "^2.3.3"
     "@peculiar/x509" "^1.9.2"
     "@types/js-levenshtein" "^1.1.3"
-    "@webrecorder/wombat" "^3.8.7"
+    "@webrecorder/wombat" "^3.8.8"
     acorn "^8.10.0"
     auto-js-ipfs "^2.1.1"
     base64-js "^1.5.1"
@@ -1058,10 +1058,10 @@
     stream-browserify "^3.0.0"
     warcio "^2.4.3"
 
-"@webrecorder/wombat@^3.8.7":
-  version "3.8.7"
-  resolved "https://registry.yarnpkg.com/@webrecorder/wombat/-/wombat-3.8.7.tgz#51c7465c589e0020be064121127c7c10a38ec21f"
-  integrity sha512-bW5V7cBweTkTazOIN8oZZGwHLevsGNv1luY3t0RYdEZhs5BDpTmUHN33zEbrXDOiPUlY3N3I8+73VA+PuxihoQ==
+"@webrecorder/wombat@^3.8.8":
+  version "3.8.8"
+  resolved "https://registry.yarnpkg.com/@webrecorder/wombat/-/wombat-3.8.8.tgz#aab4dd8eea6d6cb17bfefb7ee1802e7b45b11ed7"
+  integrity sha512-XkJOZAyHrdXNkAVoISQEh/NHzaBMekQZfWqes/k2vYkW6v9DmZ0wjP7Kf6MHCuajKX8uSH+caB2tv1kJgvnv3Q==
   dependencies:
     warcio "^2.4.0"
 


### PR DESCRIPTION
Support querying pages dynamically via pages endpoint:
- If loaded pages < total pages, load additional pages via /pages endpoint if canQueryPages is set to true on item
- If query provided, do `/pages?search=...` to search for pages. Use pagination of 25 pages for now.

WACZ hash:
- if provided, store waczhash per page, and use for thumbnail, favicon and top-level replay loading.

Embed: better support for force reloading, call delete with reload directly in embed

Depends on webrecorder/wabac.js#220