### PR TITLE
docs: Update header font

### DIFF
--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: ReplayWeb.page Docs
+site_name: Replay Webpage Docs
 docs_dir: ./site/
 watch:
   - ./site/

--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -5,7 +5,7 @@ watch:
 site_dir: _genhtml/
 repo_url: https://github.com/webrecorder/replayweb.page
 repo_name: ReplayWeb.page
-edit_uri: edit/main/mkdocs/site/docs/
+edit_uri: edit/main/mkdocs/site/
 extra_css:
   - docs/stylesheets/extra.css
 theme:

--- a/mkdocs/site/docs/stylesheets/extra.css
+++ b/mkdocs/site/docs/stylesheets/extra.css
@@ -25,12 +25,22 @@
     src: url('../assets/fonts/Inter-Italic.var.woff2') format('woff2');
     font-feature-settings: "ss03";
 }
+
+@font-face {
+    font-family: "Konsole";
+    font-weight: 100 900;
+    font-display: swap;
+    font-style: normal;
+    src: url("https://wr-static.sfo3.cdn.digitaloceanspaces.com/fonts/konsole/Konsolev1.1-VF.woff2")
+      format("woff2");
+}
   
 :root {
+    --md-display-font: "Konsole", "Helvetica", sans-serif;
     --md-code-font: "Recursive", monospace;
     --md-text-font: "Inter", "Helvetica", "Arial", sans-serif;
-    --wr-blue-primary: #0891B2;
-    --wr-orange-primary: #C96509;
+    --wr-blue-primary: #088eaf;
+    --wr-orange-primary: #bb4a00;
 }
 
 [data-md-color-scheme="webrecorder"] {
@@ -45,14 +55,22 @@
 
 /* Nav changes */
 
-.md-header__title {
-    font-family: var(--md-code-font);
-    font-variation-settings: "MONO" 0.51;
+.md-header__title,
+.md-nav__title {
+    font-family: var(--md-display-font);
+    text-transform: uppercase;
+    font-variation-settings:
+        "wght" 750,
+        "wdth" 87;
+    margin-left: 0 !important;
 }
 
 .md-header__title--active {
-    font-family: var(--md-text-font);
-    font-weight: 600;
+    font-family: var(--md-display-font);
+    text-transform: none;
+    font-variation-settings:
+        "wght" 550,
+        "wdth" 90;
 }
 
 /* Custom menu item hover */


### PR DESCRIPTION
Long overdue match to Browsertrix docs styling

Also fixes the edit link

### Screenshots
<img width="775" alt="Screenshot 2025-03-03 at 7 03 32 PM" src="https://github.com/user-attachments/assets/403abf2f-d81d-4bc9-a3c2-2e7bbb3b9cb8" />