### PR TITLE
Update actions/cache to v4

### DIFF
--- a/.github/workflows/buildapp.yaml
+++ b/.github/workflows/buildapp.yaml
@@ -25,7 +25,7 @@ jobs:
           cache: 'yarn'
 
       - name: Cache Dirs
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/electron


### PR DESCRIPTION
v2 is now deprecated and doesn't run anymore https://github.com/webrecorder/replayweb.page/actions/runs/13643415384/job/38137809743

https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

cc @ikreymer 