### PR TITLE
Fix ruffle injection + disable gdrive in library build

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## CHANGES
 
 v2.3.8
+
 - Library: disable GDrive integration in library (for AWP use)
 - Fidelity: Fix Ruffle injection, rewriting improvements (via wabac.js 2.22.17)
 - Loading: Support .wacz.zip extension for loading WACZ files when .zip is auto-added (eg. on Android devices)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## CHANGES
 
+v2.3.8
+- Library: disable GDrive integration in library (for AWP use)
+- Fidelity: Fix Ruffle injection, rewriting improvements (via wabac.js 2.22.17)
+- Loading: Support .wacz.zip extension for loading WACZ files when .zip is auto-added (eg. on Android devices)
+
 v2.3.7
 
 - Fidelity: Rewriting fixes via wabac.js 2.22.16

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "replaywebpage",
   "productName": "ReplayWeb.page",
-  "version": "2.3.7",
+  "version": "2.3.8",
   "description": "Serverless Web Archive Replay",
   "repository": "https://github.com/webrecorder/replayweb.page",
   "homepage": "https://replayweb.page/",
@@ -22,7 +22,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@shoelace-style/shoelace": "~2.15.1",
-    "@webrecorder/wabac": "^2.22.16",
+    "@webrecorder/wabac": "^2.22.17",
     "bulma": "^0.9.3",
     "electron-log": "^4.4.1",
     "electron-updater": "^6.3.9",

--- a/src/appmain.ts
+++ b/src/appmain.ts
@@ -461,6 +461,7 @@ export class ReplayWebApp extends LitElement {
     let query = "";
     if (this.useRuffle) {
       qp.set("injectScripts", "ruffle/ruffle.js");
+      qp.set("allowProxyPaths", "ruffle/");
     }
     if (this.embed) {
       qp.set("serveIndex", "1");

--- a/src/chooser.ts
+++ b/src/chooser.ts
@@ -39,7 +39,7 @@ export class Chooser extends LitElement {
         accept: {
           "application/warc": [".warc", ".gz"],
           "application/har": [".har"],
-          "application/wacz": [".wacz"],
+          "application/wacz": [".wacz", ".wacz.zip"],
           "application/json": [".json"],
         },
       },
@@ -295,7 +295,7 @@ export class Chooser extends LitElement {
                   type="text"
                   name="filename"
                   id="filename"
-                  pattern="((file|http|https|ipfs|s3)://.*.(warc|warc.gz|zip|wacz|har|json|cdx|cdxj)([?#].*)?)|(googledrive://.+)|(ssb://.+)"
+                  pattern="((file|http|https|ipfs|s3)://.*.(warc|warc.gz|zip|wacz|wacz.zip|har|json|cdx|cdxj)([?#].*)?)|(googledrive://.+)|(ssb://.+)"
                   .value="${this.fileDisplayName}"
                   @input="${this.onInput}"
                   autocomplete="off"

--- a/src/gdrive.ts
+++ b/src/gdrive.ts
@@ -194,12 +194,12 @@ class GDrive extends LitElement {
   }
 
   script() {
-    if (this.state === "trypublic" || this.scriptLoaded) {
+    if (this.state === "trypublic" || this.scriptLoaded || !__GDRIVE_API__) {
       return html``;
     }
     const script = document.createElement("script");
     script.onload = () => this.onLoad();
-    script.src = "https://apis.google.com/js/platform.js";
+    script.src = __GDRIVE_API__;
     return script;
   }
 

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -5,6 +5,7 @@ declare module "*.sass";
 declare const __SW_NAME__: string;
 declare const __HELPER_PROXY__: string;
 declare const __GDRIVE_CLIENT_ID__: string;
+declare const __GDRIVE_API__: string;
 declare const __VERSION__: string;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,6 +17,8 @@ const HELPER_PROXY = "https://helper-proxy.webrecorder.workers.dev";
 const GDRIVE_CLIENT_ID =
   "160798412227-tko4c82uopud11q105b2lvbogsj77hlg.apps.googleusercontent.com";
 
+const GDRIVE_API = "https://apis.google.com/js/platform.js";
+
 // Copyright banner text
 const BANNER_TEXT = `'[name].js is part of ReplayWeb.page (https://replayweb.page) Copyright (C) 2020-${new Date().getFullYear()}, Webrecorder Software. Licensed under the Affero General Public License v3.'`;
 
@@ -155,6 +157,7 @@ const libConfig = (env, argv) => {
         __SW_NAME__: JSON.stringify("sw.js"),
         __HELPER_PROXY__: JSON.stringify(HELPER_PROXY),
         __GDRIVE_CLIENT_ID__: JSON.stringify(GDRIVE_CLIENT_ID),
+        __GDRIVE_API__: JSON.stringify(""),
         __VERSION__: JSON.stringify(package_json.version),
       }),
       new webpack.BannerPlugin(BANNER_TEXT),
@@ -247,6 +250,7 @@ const browserConfig = (/*env, argv*/) => {
         __SW_NAME__: JSON.stringify("sw.js"),
         __HELPER_PROXY__: JSON.stringify(HELPER_PROXY),
         __GDRIVE_CLIENT_ID__: JSON.stringify(GDRIVE_CLIENT_ID),
+        __GDRIVE_API__: JSON.stringify(GDRIVE_API),
         __VERSION__: JSON.stringify(package_json.version),
       }),
       new webpack.BannerPlugin(BANNER_TEXT),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,10 +1028,10 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-2.0.5.tgz#325db42395cd49fe6c14057f9a900e427df8810e"
   integrity sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==
 
-"@webrecorder/wabac@^2.22.16":
-  version "2.22.16"
-  resolved "https://registry.yarnpkg.com/@webrecorder/wabac/-/wabac-2.22.16.tgz#8b9684569b373b8e930852bce4512e2bd2810d65"
-  integrity sha512-n39kwNOD/bKpAFwQ8AXImFqOUhfqUYoz41E0baGfoXydnJc2LKiS7SMqg3wDHazZH3y2DVlUpPknrD7UM75g0A==
+"@webrecorder/wabac@^2.22.17":
+  version "2.22.17"
+  resolved "https://registry.yarnpkg.com/@webrecorder/wabac/-/wabac-2.22.17.tgz#af1992ea78fcd6d82f3ce2a5502504d9763c08d8"
+  integrity sha512-IW7GKwE2Eh5xCj9E7OUHqmmMxdWa5GyyaVRijOFrBksgMfRAyiZxrSUlpUtALtwbyEQ1r2a5wjKyCCJE3xWubw==
   dependencies:
     "@peculiar/asn1-ecc" "^2.3.4"
     "@peculiar/asn1-schema" "^2.3.3"


### PR DESCRIPTION
library: disable GDrive integration in library build (for AWP use)
fidelity: Fix Ruffle injection, rewriting improvements (via wabac.js 2.22.17)
loading: Support .wacz.zip extension for loading WACZ files when .zip is auto-added (eg. on Android devices)

deps: bump to wabac.js 2.22.17
bump to 2.3.8