### PR TITLE
Ensure icon size is applied just to outer SVG

### DIFF
--- a/src/misc.ts
+++ b/src/misc.ts
@@ -85,7 +85,7 @@ class FaIcon extends LitElement {
         margin: 0;
         line-height: 1em;
       }
-      :host svg {
+      :host > svg {
         fill: var(--fa-icon-fill-color, currentcolor);
         width: var(--fa-icon-width, 19px);
         height: var(--fa-icon-height, 19px);


### PR DESCRIPTION
Due to changes in chrome (https://issues.chromium.org/issues/40409865), width and height presentation attributes within nested SVGs are now respected, which breaks icons styling in RWP. This fixes that by ensuring that the styling that sets width and height on the outer icon SVG _only_ applies to the outer SVG, allowing the inner SVG's intrinsic/declared size to be respected properly.

Tested in latest chrome, firefox, and safari on macos.

Fixes #457