### PR TITLE
ui/replay fidelity: add 'color-theme: light dark' to replay container

### DIFF
--- a/src/replay.ts
+++ b/src/replay.ts
@@ -320,6 +320,7 @@ class Replay extends LitElement {
         display: flex;
         flex-direction: column;
         height: 100%;
+        color-scheme: light dark;
       }
 
       .iframe-container {


### PR DESCRIPTION
allows propagating the theme to replay iframe!

fixes part of issues with webrecorder/archiveweb.page#320 where different resources are loaded based on theme