### PR TITLE
deps: update to wabac.js 2.25.3 to fix WACZ loading bug

### DIFF
--- a/.github/workflows/npm-release.yaml
+++ b/.github/workflows/npm-release.yaml
@@ -3,23 +3,28 @@ on:
   release:
     types: [published]
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 jobs:
   build-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
-          registry-url: 'https://registry.npmjs.org'
-          cache: 'yarn'
+          node-version: "24.x"
+          registry-url: "https://registry.npmjs.org"
+          cache: "yarn"
 
       - name: Yarn Install
         run: yarn install --frozen-lockfile
 
-      - name: Yarn Build
+      - name: Yarn Run Build
         run: yarn run build
 
-      - run: npm publish
+      - name: Npm Publish!
+        run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "replaywebpage",
   "productName": "ReplayWeb.page",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Serverless Web Archive Replay",
   "repository": "https://github.com/webrecorder/replayweb.page",
   "homepage": "https://replayweb.page/",
@@ -22,7 +22,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@shoelace-style/shoelace": "~2.15.1",
-    "@webrecorder/wabac": "^2.25.2",
+    "@webrecorder/wabac": "^2.25.3",
     "bulma": "^0.9.3",
     "electron-log": "^4.4.1",
     "electron-updater": "^6.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1060,10 +1060,10 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-2.0.5.tgz#325db42395cd49fe6c14057f9a900e427df8810e"
   integrity sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==
 
-"@webrecorder/wabac@^2.25.2":
-  version "2.25.2"
-  resolved "https://registry.yarnpkg.com/@webrecorder/wabac/-/wabac-2.25.2.tgz#545d29e00a82031333005f0cfa179a8b92f0f6f1"
-  integrity sha512-leu+GmHYlzNFeIjnOhuAi0dUYyYquaHFyUatve8oPGhQUHG4jmO9ijydq8t71i90Rs01aEsNV3N7+je4CFLIhg==
+"@webrecorder/wabac@^2.25.3":
+  version "2.25.3"
+  resolved "https://registry.yarnpkg.com/@webrecorder/wabac/-/wabac-2.25.3.tgz#c60dce925d915b0e48de12cba2ea9af282080fb5"
+  integrity sha512-9VZW0NvPqvJN5tgR0hA8O49w1gXXhXBhp5oQhxtEZ5Ldulbl6q4cn5pRE3HItrYVmUOHoma5iPyYZRKaCbyOig==
   dependencies:
     "@peculiar/asn1-ecc" "^2.3.4"
     "@peculiar/asn1-schema" "^2.3.3"


### PR DESCRIPTION
ci: update npm release action for npm authorized builds bump to 2.4.1