### PR TITLE
ui: ensure iso string 'ts' is parsed into timestamp ts + wabac.js 2.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@shoelace-style/shoelace": "~2.15.1",
-    "@webrecorder/wabac": "^2.26.0-beta.0",
+    "@webrecorder/wabac": "^2.26.0",
     "bulma": "^0.9.3",
     "electron-log": "^4.4.1",
     "electron-updater": "^6.6.2",

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -441,6 +441,10 @@ class Pages extends LitElement {
         }
 
         line.id = ++count;
+
+        if (typeof line.ts === "string") {
+          line.ts = new Date(line.ts as string).getTime();
+        }
         lines.push(line);
       }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1060,22 +1060,22 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-2.0.5.tgz#325db42395cd49fe6c14057f9a900e427df8810e"
   integrity sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==
 
-"@webrecorder/wabac@^2.26.0-beta.0":
-  version "2.26.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@webrecorder/wabac/-/wabac-2.26.0-beta.0.tgz#ebc7b5a7d7b9d50efbcdcde0abebdd97d92cf371"
-  integrity sha512-HlVt7L4AlTafL/Je9ueCO5bcLqgvW8c9WZlm42bY3eYau4wYisvlldWGqCv+FzVXo+MxU1SFlcSd83N83rYYkQ==
+"@webrecorder/wabac@^2.26.0":
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/@webrecorder/wabac/-/wabac-2.26.0.tgz#4446c9a3c242d65e38312eb2776a6056ae0d345a"
+  integrity sha512-Tgh3BO8v/3OoKlFPQsSA7oMyCG8HvP0Caosu5SEgUpgnYzI5r2WYnADZSeni24fMoaW2YYrdo/GW9b+pgV5C1g==
   dependencies:
     "@peculiar/asn1-ecc" "^2.3.4"
     "@peculiar/asn1-schema" "^2.3.3"
     "@peculiar/x509" "^1.9.2"
     "@types/js-levenshtein" "^1.1.3"
-    "@webrecorder/wombat" "^3.10.3"
+    "@webrecorder/wombat" "^3.10.4"
     acorn "^8.15.0"
     auto-js-ipfs "^2.1.1"
     base64-js "^1.5.1"
     brotli "^1.3.3"
     buffer "^6.0.3"
-    fast-xml-parser "^4.4.1"
+    fast-xml-parser "^4.5.4"
     hash-wasm "^4.9.0"
     http-status-codes "^2.1.4"
     idb "^7.1.1"
@@ -1088,14 +1088,14 @@
     path-parser "^6.1.0"
     process "^0.11.10"
     stream-browserify "^3.0.0"
-    warcio "^2.4.7"
+    warcio "^2.4.10"
 
-"@webrecorder/wombat@^3.10.3":
-  version "3.10.3"
-  resolved "https://registry.yarnpkg.com/@webrecorder/wombat/-/wombat-3.10.3.tgz#f49fae3aedb54d75120de8286360b2fe40f42bda"
-  integrity sha512-tg1zRFlWUcYBsSMFCNf4zprCxlRfLmd7DnGsufRHS8fX0aJAMU3jNSE00Q9pWTcdIsxXQCNk4OT9FTlErCxRrg==
+"@webrecorder/wombat@^3.10.4":
+  version "3.10.4"
+  resolved "https://registry.yarnpkg.com/@webrecorder/wombat/-/wombat-3.10.4.tgz#acfd89443dff0980fbe1c16835bd85fdfbb739f0"
+  integrity sha512-ZD93jbfD9Te/TDehMtC1Gp7ylJYb8HYl1ct3xt1h+e6eJthYkrGgOeOkH7sGEKlK83R/RGX/WthADBoJrTsF6A==
   dependencies:
-    warcio "^2.4.7"
+    warcio "^2.4.10"
 
 "@xmldom/xmldom@^0.8.8":
   version "0.8.10"
@@ -2788,10 +2788,10 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
-fast-xml-parser@^4.4.1:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz#86dbf3f18edf8739326447bcaac31b4ae7f6514f"
-  integrity sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==
+fast-xml-parser@^4.5.4:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.5.5.tgz#c873d9ba4a589eae7010929bb891db5289d852d3"
+  integrity sha512-cK9c5I/DwIOI7/Q7AlGN3DuTdwN61gwSfL8rvuVPK+0mcCNHHGxRrpiFtaZZRfRMJL3Gl8B2AFlBG6qXf03w9A==
   dependencies:
     strnum "^1.0.5"
 
@@ -6464,10 +6464,10 @@ vscode-uri@^2.1.2:
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-2.1.2.tgz#c8d40de93eb57af31f3c715dd650e2ca2c096f1c"
   integrity sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==
 
-warcio@^2.4.7:
-  version "2.4.7"
-  resolved "https://registry.yarnpkg.com/warcio/-/warcio-2.4.7.tgz#7c3918463e550f62fe63df5f76a871424e74097a"
-  integrity sha512-WGRqvoUqSalAkx+uJ8xnrxiiSPZ7Ru/h7iKC2XmuMMSOUSnS917l4V+qpaN9thAsZkZ+8qJRtee3uyOjlq4Dgg==
+warcio@^2.4.10:
+  version "2.4.10"
+  resolved "https://registry.yarnpkg.com/warcio/-/warcio-2.4.10.tgz#1d873b9c469a331441919776c2cad84dece878c3"
+  integrity sha512-jaqgnavBT//6scEMUGqi5eK2NXIZ8Tp8LJOY+oa07k7JpIt/BwQLJL3dQca/SgPHaW0yspQmi1IeF0p1wrUcaA==
   dependencies:
     "@types/pako" "^1.0.7"
     "@types/stream-buffers" "^3.0.7"


### PR DESCRIPTION
deps: update to wabac.js 2.26.0 for optimizations for wacz loading + proxy rewrite mode