### PR TITLE
Fixed precision in progress percentage display

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -474,7 +474,7 @@ class Loader extends LitElement {
       ${displayPercent
         ? html`
             <label class="progress-label" for="progress"
-              >${displayPercent}%</label
+              >${displayPercent.toFixed(2)}%</label
             >
           `
         : nothing}


### PR DESCRIPTION
Currently, when loading a file for processing, the percentage display underneath the progress bar jumps around with arbitrary float precision. Fixing it to 2 decimal places would make it more readable.