### PR TITLE
feat: Expose replay navigation method

### DIFF
--- a/src/appmain.ts
+++ b/src/appmain.ts
@@ -6,7 +6,7 @@ import {
   type TemplateResult,
   type PropertyValues,
 } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import { customElement, property, query } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import {
   wrapCss,
@@ -26,7 +26,13 @@ import { SWManager } from "./swmanager";
 import "./item";
 import "./item-index";
 import "./chooser";
-import { type EmbedOpts, type LoadInfo } from "./item";
+import {
+  type Item,
+  type EmbedOpts,
+  type LoadInfo,
+  RWP_SCHEME,
+  EmbedReplayDataView,
+} from "./item";
 import type { FavIconEventDetail } from "./types";
 
 // ===========================================================================
@@ -80,7 +86,40 @@ export class ReplayWebApp extends LitElement {
   @property({ type: String })
   swErrorMsg: TemplateResult<1> | string | null = null;
 
-  protected swName?: string;
+  @query("wr-item")
+  private readonly item?: Item | null;
+
+  /**
+   * Navigate to a view in replay.
+   *
+   * @param {string} urlOrView - The page URL or view to navigate to.
+   * @param {Object|undefined} data - Optional view data.
+   */
+  public navigateReplayTo(
+    urlOrView: EmbedReplayDataView | string,
+    data?: { ts: string },
+  ) {
+    if (!this.item) {
+      console.debug("missing `this.item`");
+      return;
+    }
+
+    let value = urlOrView;
+
+    if (
+      Object.values(EmbedReplayDataView).some(
+        (view) => (view as string) === urlOrView,
+      )
+    ) {
+      value = `${RWP_SCHEME}view=${value}${
+        data ? `?${new URLSearchParams(data).toString()}` : ""
+      }`;
+    }
+
+    this.item.navigateTo(value, data);
+  }
+
+  swName?: string;
   protected swmanager: SWManager | null;
   private useRuffle = false;
 

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -460,8 +460,6 @@ class Embed extends LitElement {
       this.reloadCount <= 2
     ) {
       this.reloadCount++;
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       setTimeout(() => win.location.reload(), 100);
       return;
     }

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -261,20 +261,16 @@ class Embed extends LitElement {
     const qs = new URLSearchParams(window.location.hash.slice(1));
 
     if (qs.has("url")) {
-      // @ts-expect-error - TS2339 - Property 'url' does not exist on type 'Embed'.
-      this.url = qs.get("url");
+      this.url = qs.get("url") ?? "";
     }
     if (qs.has("ts")) {
-      // @ts-expect-error - TS2339 - Property 'ts' does not exist on type 'Embed'.
-      this.ts = qs.get("ts");
+      this.ts = qs.get("ts") ?? "";
     }
     if (qs.has("query")) {
-      // @ts-expect-error - TS2339 - Property 'query' does not exist on type 'Embed'.
-      this.query = qs.get("query");
+      this.query = qs.get("query") ?? "";
     }
     if (qs.has("view")) {
-      // @ts-expect-error - TS2339 - Property 'view' does not exist on type 'Embed'.
-      this.view = qs.get("view");
+      this.view = qs.get("view") ?? "";
     }
   }
 

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -13,6 +13,7 @@ import { property, query } from "lit/decorators.js";
 import type { FavIconEventDetail } from "./types";
 import type { EmbedReplayData } from "./item";
 import type { RwpPageLoadingEvent, RwpUrlChangeEvent } from "./events";
+import type { ReplayWebApp } from "./appmain";
 
 type IframeMessage = MessageEvent<
   | RwpUrlChangeEvent["detail"]
@@ -87,6 +88,8 @@ class Embed extends LitElement {
 
   @query("iframe")
   private readonly iframe?: HTMLIFrameElement | null;
+
+  mainElement?: ReplayWebApp | null;
 
   replayfile = defaultReplayFile;
   mainElementName = "replay-app-main";
@@ -442,17 +445,17 @@ class Embed extends LitElement {
     `;
   }
 
-  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
-  onLoad(event) {
+  onLoad(event: Event) {
     if (this.isCrossOrigin) {
       return;
     }
 
-    const win = event.target.contentWindow;
-    const doc = event.target.contentDocument;
+    const target = event.target as HTMLIFrameElement;
+    const win = target.contentWindow;
+    const doc = target.contentDocument;
 
     if (
-      win.navigator.serviceWorker &&
+      win?.navigator.serviceWorker &&
       !win.navigator.serviceWorker.controller &&
       this.reloadCount <= 2
     ) {
@@ -465,7 +468,18 @@ class Embed extends LitElement {
 
     this.reloadCount = 0;
 
-    if (win.customElements.get(this.mainElementName)) {
+    if (win?.customElements.get(this.mainElementName)) {
+      this.mainElement = doc?.querySelector(this.mainElementName);
+      return;
+    }
+
+    if (!doc) {
+      console.debug("missing `event.target.contentDocument`");
+      return;
+    }
+
+    if (!scriptSrc) {
+      console.debug("missing `scriptSrc`");
       return;
     }
 

--- a/src/item.ts
+++ b/src/item.ts
@@ -302,9 +302,14 @@ class Item extends LitElement {
         void this.getMultiTimestamps();
       }
     }
-  }
+    if (changedProperties.has("tabData") && this.itemInfo?.coll) {
+      if (!this.tabData.url) {
+        this.url =
+          RWP_SCHEME + decodeURIComponent(this._paramsToString(this.tabData));
+      }
 
-  updated(changedProperties: PropertyValues<this>) {
+      this._locUpdateNeeded = false;
+    }
     if (changedProperties.has("sourceUrl")) {
       void this.doUpdateInfo();
     }
@@ -313,18 +318,18 @@ class Item extends LitElement {
         this._autoUpdater = this.runUpdateLoop();
       }
     }
+  }
+
+  updated(changedProperties: PropertyValues<this>) {
     if (changedProperties.has("tabData")) {
       if (!this.itemInfo?.coll) {
         return;
       }
+
       const newHash =
         "#" +
         new URLSearchParams(this.tabData as Record<string, string>).toString();
 
-      if (!this.tabData.url) {
-        this.url =
-          RWP_SCHEME + decodeURIComponent(this._paramsToString(this.tabData));
-      }
       if (newHash !== this._locationHash) {
         this._locationHash = newHash;
 
@@ -372,7 +377,6 @@ class Item extends LitElement {
           }
         }
       }
-      this._locUpdateNeeded = false;
     }
     if (changedProperties.has("showSidebar")) {
       if (!this.embed) {

--- a/src/item.ts
+++ b/src/item.ts
@@ -64,7 +64,7 @@ import type {
   TabNavEvent,
 } from "./events";
 
-const RWP_SCHEME = "search://";
+export const RWP_SCHEME = "search://";
 
 export type LoadInfo = {
   extraConfig?: {
@@ -91,8 +91,14 @@ export type EmbedOpts = {
   noMediaDownloadUI?: boolean;
 };
 
+export enum EmbedReplayDataView {
+  Story = "story",
+  Pages = "pages",
+  Resources = "resources",
+}
+
 export type EmbedReplayData = {
-  view?: "story" | "pages" | "resources";
+  view?: EmbedReplayDataView;
   url?: string;
   ts?: string;
   title?: string;
@@ -534,12 +540,12 @@ class Item extends LitElement {
       (!this.tabData.view || !this.tabNames.includes(this.tabData.view))
     ) {
       const view = this.hasStory
-        ? "story"
+        ? EmbedReplayDataView.Story
         : // TODO: Fix this the next time the file is edited.
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         this.editable || this.itemInfo.pages?.length
-        ? "pages"
-        : "resources";
+        ? EmbedReplayDataView.Pages
+        : EmbedReplayDataView.Resources;
 
       this.tabData = {
         ...this.tabData,
@@ -560,8 +566,8 @@ class Item extends LitElement {
       }
     }
 
-    if (!this.hasStory && this.tabData.view === "story") {
-      this.tabData.view = "pages";
+    if (!this.hasStory && this.tabData.view === EmbedReplayDataView.Story) {
+      this.tabData.view = EmbedReplayDataView.Pages;
     }
 
     if (this.tabData.url && this.tabData.query && this.browsable) {
@@ -1907,14 +1913,13 @@ class Item extends LitElement {
     this.updateTabData({ ts: item.value });
   }
 
-  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'value' implicitly has an 'any' type.
-  navigateTo(value) {
+  navigateTo(value: string, { ts } = { ts: "" }) {
     let data: TabData;
 
     if (value.startsWith("http://") || value.startsWith("https://")) {
-      data = { url: value };
+      data = { url: value, ts };
 
-      if (value === this.tabData.url) {
+      if (value === this.tabData.url && (!ts || ts === this.tabData.ts)) {
         const replay = this.renderRoot.querySelector<Replay>("wr-coll-replay");
         if (replay) {
           replay.refresh();
@@ -1923,18 +1928,16 @@ class Item extends LitElement {
       }
     } else {
       if (!value.startsWith(RWP_SCHEME)) {
-        data = { query: value, view: "pages" };
+        data = { query: value, view: EmbedReplayDataView.Pages };
       } else {
         data = this._stringToParams(value);
       }
     }
+
     this.updateTabData(data);
   }
 
-  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'value' implicitly has an 'any' type.
-  _stringToParams(value) {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  _stringToParams(value: string) {
     const q = new URLSearchParams(value.slice(RWP_SCHEME.length));
     const data: Partial<URLResource> = {};
     data.url = "";

--- a/src/item.ts
+++ b/src/item.ts
@@ -603,7 +603,7 @@ class Item extends LitElement {
     }
 
     if (
-      targetId === this.tabData.view ||
+      targetId === (this.tabData.view as string) ||
       (targetId === "replay" && this.tabData.url) ||
       (this.showSidebar && this.tabData.url)
     ) {
@@ -1077,7 +1077,9 @@ class Item extends LitElement {
           : ""}
         ${this.hasStory
           ? html` <li
-              class="${this.tabData.view === "story" ? "is-active" : ""}"
+              class="${this.tabData.view === EmbedReplayDataView.Story
+                ? "is-active"
+                : ""}"
             >
               <a
                 @click="${this.onTabClick}"
@@ -1085,7 +1087,9 @@ class Item extends LitElement {
                 class="is-size-6"
                 aria-label="Story"
                 aria-current="${ifDefined(
-                  this.tabData.view === "story" ? "location" : undefined,
+                  this.tabData.view === EmbedReplayDataView.Story
+                    ? "location"
+                    : undefined,
                 )}"
               >
                 <span class="icon"
@@ -1104,14 +1108,20 @@ class Item extends LitElement {
             </li>`
           : ""}
 
-        <li class="${this.tabData.view === "pages" ? "is-active" : ""}">
+        <li
+          class="${this.tabData.view === EmbedReplayDataView.Pages
+            ? "is-active"
+            : ""}"
+        >
           <a
             @click="${this.onTabClick}"
             href="#pages"
             class="is-size-6"
             aria-label="Pages"
             aria-current="${ifDefined(
-              this.tabData.view === "pages" ? "location" : undefined,
+              this.tabData.view === EmbedReplayDataView.Pages
+                ? "location"
+                : undefined,
             )}"
           >
             <span class="icon"
@@ -1125,14 +1135,20 @@ class Item extends LitElement {
           </a>
         </li>
 
-        <li class="${this.tabData.view === "resources" ? "is-active" : ""}">
+        <li
+          class="${this.tabData.view === EmbedReplayDataView.Resources
+            ? "is-active"
+            : ""}"
+        >
           <a
             @click="${this.onTabClick}"
             href="#resources"
             class="is-size-6"
             aria-label="URLs"
             aria-current="${ifDefined(
-              this.tabData.view === "resources" ? "location" : undefined,
+              this.tabData.view === EmbedReplayDataView.Resources
+                ? "location"
+                : undefined,
             )}"
           >
             <span class="icon"

--- a/src/item.ts
+++ b/src/item.ts
@@ -1655,9 +1655,10 @@ class Item extends LitElement {
 
   // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'isSidebar' implicitly has an 'any' type.
   renderItemTabs(isSidebar) {
-    const isStory = this.hasStory && this.tabData.view === "story";
-    const isPages = this.tabData.view === "pages";
-    const isResources = this.tabData.view === "resources";
+    const isStory =
+      this.hasStory && this.tabData.view === EmbedReplayDataView.Story;
+    const isPages = this.tabData.view === EmbedReplayDataView.Pages;
+    const isResources = this.tabData.view === EmbedReplayDataView.Resources;
 
     return html`
       ${isStory

--- a/src/replay.ts
+++ b/src/replay.ts
@@ -1,11 +1,12 @@
 import { LitElement, html, css, type PropertyValues } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
-import { property } from "lit/decorators.js";
+import { property, query, state } from "lit/decorators.js";
 
 import { wrapCss } from "./misc";
 import rwpLogo from "~assets/brand/replaywebpage-icon-color.svg";
 import type { ItemType } from "./types";
 import type { ReplayLoadingDetail, TabNavEvent } from "./events";
+import { keyed } from "lit/directives/keyed.js";
 
 /**
  * @fires update-title
@@ -61,6 +62,17 @@ class Replay extends LitElement {
 
   @property({ type: String })
   downloadResUrl = "";
+
+  @query("iframe")
+  readonly iframe?: HTMLIFrameElement | null;
+
+  /**
+   * Use key to force iframe to update even if `src` hasn't changed,
+   * for example, if the iframe window has navigated to a linked page
+   * and is being externally reset to a seed URL.
+   */
+  @state()
+  private iframeUrlUpdateKey?: number;
 
   private reauthWait: null | Promise<void> = null;
 
@@ -146,7 +158,13 @@ class Replay extends LitElement {
       this.replayTS = this.ts;
       this.showAuth = false;
       this.reauthWait = null;
+
+      const prevIframe = this.iframeUrl;
       this.doSetIframeUrl();
+
+      if (prevIframe === this.iframeUrl) {
+        this.iframeUrlUpdateKey = Date.now();
+      }
     }
   }
 
@@ -445,16 +463,18 @@ class Replay extends LitElement {
               )}"
             ></a>
             <div class="iframe-container">
-              <iframe
-                class="iframe-main"
-                name="___wb_replay_top_frame"
-                @message="${this.onReplayMessage}"
-                allow="autoplay 'self'; fullscreen"
-                allowfullscreen
-                src="${this.iframeUrl}"
-                title="${title}"
-              ></iframe>
-
+              ${keyed(
+                this.iframeUrlUpdateKey,
+                html`<iframe
+                  class="iframe-main"
+                  name="___wb_replay_top_frame"
+                  @message="${this.onReplayMessage}"
+                  allow="autoplay 'self'; fullscreen"
+                  allowfullscreen
+                  src="${this.iframeUrl}"
+                  title="${title}"
+                ></iframe>`,
+              )}
               ${this.showAuth
                 ? html`
                     <div class="iframe-main modal-bg">

--- a/src/replay.ts
+++ b/src/replay.ts
@@ -68,6 +68,14 @@ class Replay extends LitElement {
 
   private hiliter: HoverHiliter | null = null;
 
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+
+    if (this._loadPoll) {
+      window.clearInterval(this._loadPoll);
+    }
+  }
+
   firstUpdated() {
     window.addEventListener("message", (event) => this.onReplayMessage(event));
     // TODO: Fix this the next time the file is edited.
@@ -121,7 +129,7 @@ class Replay extends LitElement {
         : "";
   }
 
-  updated(changedProperties: PropertyValues<this>) {
+  willUpdate(changedProperties: PropertyValues<this>) {
     if (
       changedProperties.has("sourceUrl") ||
       changedProperties.has("collInfo")
@@ -140,7 +148,9 @@ class Replay extends LitElement {
       this.reauthWait = null;
       this.doSetIframeUrl();
     }
+  }
 
+  updated(changedProperties: PropertyValues<this>) {
     if (this.iframeUrl && changedProperties.has("iframeUrl")) {
       this.waitForLoad();
 


### PR DESCRIPTION
Blocks https://github.com/webrecorder/browsertrix/issues/3338

- Adds public `navigateReplayTo` method in `<replay-app-main>` that allows embeds to control replay navigation directly without reloading entire UI.
- Enables reloading `<wr-coll-replay>` iframe even if source URL hasn't changed.
- Refactors lifecycle events to prevent unnecessary re-renders.