### PR TITLE
fix: Page sidebar improvements

### DIFF
--- a/src/appmain.ts
+++ b/src/appmain.ts
@@ -48,6 +48,9 @@ export class ReplayWebApp extends LitElement {
   showAbout = false;
 
   @property({ type: Boolean })
+  hideNonSeedPages = false;
+
+  @property({ type: Boolean })
   showFileDropOverlay = false;
 
   @property({ type: String })
@@ -404,6 +407,7 @@ export class ReplayWebApp extends LitElement {
       .embedOpts="${this.embedOpts}"
       appName="${this.appName}"
       swName="${ifDefined(this.swName)}"
+      ?showAllPages=${!this.hideNonSeedPages}
       @replay-favicons=${this.onFavIcons}
       @update-title=${this.onTitle}
       @coll-loaded=${this.onCollLoaded}

--- a/src/item.ts
+++ b/src/item.ts
@@ -130,6 +130,9 @@ class Item extends LitElement {
   @property({ type: Boolean })
   showSidebar: boolean | null = null;
 
+  @property({ type: Boolean })
+  showAllPages = false;
+
   @property({ type: Object, attribute: false })
   itemInfo: ItemType | Record<string, never> | null = null;
 
@@ -1680,6 +1683,7 @@ class Item extends LitElement {
             query="${this.tabData.query || ""}"
             .url="${this.tabData.url || ""}"
             .ts="${this.tabData.ts || ""}"
+            ?showAllPages=${this.showAllPages}
             @coll-tab-nav="${this.onItemTabNav}"
             id="pages"
             @coll-update="${this.onItemUpdate}"

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -520,8 +520,7 @@ class Pages extends LitElement {
         border-right: 1px solid var(--sl-panel-border-color);
         background-color: var(--sl-color-neutral-100);
         position: relative;
-        padding: var(--sl-spacing-medium) 0 var(--sl-spacing-medium)
-          var(--sl-spacing-medium);
+        padding: 0;
       }
 
       .index-bar-label {
@@ -529,15 +528,25 @@ class Pages extends LitElement {
         font-size: var(--sl-font-size-x-small);
         font-weight: var(--sl-font-weight-semibold);
         color: var(--sl-color-neutral-500);
-        margin-bottom: var(--sl-spacing-2x-small);
+        margin-bottom: var(--sl-spacing-x-small);
+        padding: 0 var(--sl-spacing-small);
         line-height: 1;
+      }
+
+      .index-bar-label:first-child {
+        margin-top: var(--sl-spacing-medium);
       }
 
       .index-bar-title {
         font-size: var(--sl-font-size-small);
         font-weight: var(--sl-font-weight-semibold);
         margin-bottom: var(--sl-spacing-small);
+        padding: 0 var(--sl-spacing-small);
         word-break: break-word;
+      }
+
+      .index-bar-title + .index-bar-label {
+        margin-top: var(--sl-spacing-medium);
       }
 
       .index-bar-title:hover + .editIcon {
@@ -595,10 +604,13 @@ class Pages extends LitElement {
         display: flex;
         align-items: center;
         gap: var(--sl-spacing-x-small);
+        line-height: 1;
       }
 
       .index-bar .seed-pages-filter {
-        margin-bottom: var(--sl-spacing-small);
+        font-weight: var(--sl-font-weight-semibold);
+        margin-bottom: var(--sl-spacing-medium);
+        padding: var(--sl-spacing-small);
       }
 
       .sorter {
@@ -730,12 +742,10 @@ class Pages extends LitElement {
 
       .index-bar-description {
         font-size: var(--sl-font-size-small);
-        margin-top: var(--sl-spacing-medium);
-        margin-bottom: var(--sl-spacing-small);
         line-height: var(--sl-line-height-normal);
         flex: 1 1 auto;
         overflow: auto;
-        border-bottom: 1px solid var(--sl-panel-border-color);
+        padding: 0 var(--sl-spacing-small);
       }
     `);
   }
@@ -835,6 +845,7 @@ class Pages extends LitElement {
             ? "is-hidden-mobile"
             : ""}"
         >
+          ${this.renderSeedPagesFilter()}
           ${this.editable && this.editing
             ? html`
                 <form @submit="${this.onUpdateTitle}">
@@ -871,7 +882,6 @@ class Pages extends LitElement {
           ${this.editable
             ? html`<fa-icon class="editIcon" .svg="${fasEdit}"></fa-icon>`
             : html``}
-          ${this.renderSeedPagesFilter()}
           ${this.editable
             ? html` <div class="index-bar-actions">
                 ${this.renderDownloadMenu()}

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -511,24 +511,25 @@ class Pages extends LitElement {
         display: flex;
         flex-direction: column;
         border-right: 3px solid rgb(237, 237, 237);
-        background-color: whitesmoke;
-        padding-right: 0px;
+        background-color: var(--sl-color-neutral-100);
         position: relative;
+        padding: var(--sl-spacing-medium) 0 var(--sl-spacing-medium)
+          var(--sl-spacing-medium);
       }
 
       .index-bar-label {
         text-transform: uppercase;
-        font-size: var(--sl-font-size-x-small);
+        font-size: var(--sl-font-size-2x-small);
         font-weight: var(--sl-font-weight-semibold);
         color: var(--sl-color-neutral-500);
-        margin-bottom: var(--sl-spacing-2x-small);
+        margin-bottom: var(--sl-spacing-x-small);
         line-height: 1;
       }
 
       .index-bar-title {
-        font-size: var(--sl-font-size-large);
+        font-size: var(--sl-font-size-small);
         font-weight: var(--sl-font-weight-semibold);
-        margin-bottom: var(--sl-spacing-large);
+        margin-bottom: var(--sl-spacing-medium);
         word-break: break-word;
       }
 
@@ -559,9 +560,9 @@ class Pages extends LitElement {
       }
 
       .num-results {
-        font-style: italic;
         font-weight: normal;
-        line-height: 2.5;
+        font-size: var(--sl-font-size-small);
+        line-height: 1;
       }
 
       .asc:after {
@@ -650,6 +651,9 @@ class Pages extends LitElement {
         width: auto;
         display: flex;
         flex-direction: column;
+        padding: var(--sl-spacing-medium);
+        background-color: var(--sl-color-neutral-100);
+        border-bottom: 1px solid var(--sl-panel-border-color);
       }
 
       .flex-auto {
@@ -657,7 +661,8 @@ class Pages extends LitElement {
       }
 
       .index-bar-description {
-        margin-bottom: var(--sl-spacing-x-small);
+        font-size: var(--sl-font-size-small);
+        margin-bottom: var(--sl-spacing-small);
         line-height: var(--sl-line-height-normal);
         flex: 1 1 auto;
         overflow: auto;
@@ -731,7 +736,7 @@ class Pages extends LitElement {
       >
         Pages in ${this.collInfo!.title}
       </div>
-      <div class="search-bar notification is-marginless">
+      <div class="search-bar is-marginless">
         ${this.isSidebar
           ? html`<h3 class="is-sr-only">Search and Filter Pages</h3>`
           : ""}
@@ -769,11 +774,7 @@ class Pages extends LitElement {
                   />
                 </form>
               `
-            : html` <div
-                  class="index-bar-label ${this.collInfo!.description
-                    ? "is-hidden-mobile"
-                    : "is-sr-only"}"
-                >
+            : html` <div class="index-bar-label is-hidden-mobile">
                   Collection Name
                 </div>
                 <div
@@ -1312,11 +1313,15 @@ class Pages extends LitElement {
     const total = collTotal || filteredTotal;
     const shown = this.sortedPages.length;
 
+    const totalStr = `${total.toLocaleString()} ${
+      total === 1 ? "Page" : "Pages"
+    }`;
+
     if (total === shown) {
-      return `${total} ${total === 1 ? "Page" : "Pages"}`;
+      return totalStr;
     }
 
-    return `${shown} of ${total} Pages Shown`;
+    return `${shown.toLocaleString()} of ${totalStr}`;
   }
 
   getNoResultsMessage() {

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -1,6 +1,13 @@
 "use strict";
 
-import { LitElement, html, css, unsafeCSS, type PropertyValues } from "lit";
+import {
+  LitElement,
+  html,
+  css,
+  unsafeCSS,
+  type PropertyValues,
+  nothing,
+} from "lit";
 import { property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { wrapCss, clickOnSpacebarPress } from "./misc";
@@ -13,6 +20,7 @@ import { getTS, getPageDateTS } from "./pageutils";
 
 import fasSearch from "@fortawesome/fontawesome-free/svgs/solid/search.svg";
 import fasAngleDown from "@fortawesome/fontawesome-free/svgs/solid/angle-down.svg";
+import faArrowDown from "@fortawesome/fontawesome-free/svgs/solid/arrow-down.svg";
 import fasEdit from "@fortawesome/fontawesome-free/svgs/solid/edit.svg";
 
 import type { Sorter } from "./sorter";
@@ -483,6 +491,7 @@ class Pages extends LitElement {
       .header.columns {
         width: 100%;
         margin-bottom: 0px;
+        padding: var(--sl-spacing-x-small) var(--sl-spacing-small);
       }
       .header a {
         color: black;
@@ -497,8 +506,6 @@ class Pages extends LitElement {
         display: flex;
         flex-direction: column;
         padding: 0px;
-        margin-top: 0.5em;
-        margin-left: 0.75em;
       }
 
       .thumbnail {
@@ -510,7 +517,7 @@ class Pages extends LitElement {
       .index-bar {
         display: flex;
         flex-direction: column;
-        border-right: 3px solid rgb(237, 237, 237);
+        border-right: 1px solid var(--sl-panel-border-color);
         background-color: var(--sl-color-neutral-100);
         position: relative;
         padding: var(--sl-spacing-medium) 0 var(--sl-spacing-medium)
@@ -519,7 +526,7 @@ class Pages extends LitElement {
 
       .index-bar-label {
         text-transform: uppercase;
-        font-size: var(--sl-font-size-2x-small);
+        font-size: var(--sl-font-size-x-small);
         font-weight: var(--sl-font-weight-semibold);
         color: var(--sl-color-neutral-500);
         margin-bottom: var(--sl-spacing-2x-small);
@@ -560,9 +567,24 @@ class Pages extends LitElement {
       }
 
       .num-results {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: var(--sl-spacing-small);
+        justify-content: space-between;
         font-weight: normal;
         font-size: var(--sl-font-size-small);
+        color: var(--sl-color-neutral-700);
         line-height: 1;
+        border-top: 1px solid var(--sl-panel-border-color);
+      }
+
+      .main-num-results {
+        padding: var(--sl-spacing-x-small) var(--sl-spacing-small);
+      }
+
+      .sidebar-num-results {
+        padding: var(--sl-spacing-x-small);
       }
 
       .seed-pages-filter {
@@ -584,18 +606,23 @@ class Pages extends LitElement {
         align-items: center;
       }
 
-      .sorter .num-results {
-        width: 100%;
-      }
-
       .sorter wr-sorter {
         flex-grow: 1;
       }
 
       .sorter .seed-pages-filter {
         flex-shrink: 0;
-        font-weight: normal;
         font-size: var(--sl-font-size-x-small);
+      }
+
+      .sort-control-label {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--sl-spacing-2x-small);
+        font-size: var(--sl-font-size-small);
+        font-weight: var(--sl-font-weight-semibold);
+        color: var(--sl-color-neutral-600);
+        padding-bottom: 0;
       }
 
       .asc:after {
@@ -647,9 +674,16 @@ class Pages extends LitElement {
         display: flex;
         flex-direction: column;
         flex: auto;
-
-        padding-bottom: 1em;
+        padding: var(--sl-spacing-small);
         min-height: 0px;
+      }
+
+      .scroller-help-text {
+        color: var(--sl-color-neutral-500);
+      }
+
+      .scroller-help-text .icon {
+        font-size: 10px;
       }
 
       .page-entry {
@@ -671,18 +705,23 @@ class Pages extends LitElement {
         align-items: baseline;
         width: 100%;
         min-height: fit-content;
-
-        margin-bottom: 1em;
-        border-bottom: 3px solid rgb(237, 237, 237);
+        border-bottom: 1px solid var(--sl-panel-border-color);
       }
 
       .search-bar {
         width: auto;
         display: flex;
         flex-direction: column;
-        padding: var(--sl-spacing-small);
         background-color: var(--sl-color-neutral-100);
         border-bottom: 1px solid var(--sl-panel-border-color);
+      }
+
+      .main-search-bar {
+        padding: var(--sl-spacing-small);
+      }
+
+      .sidebar-search-bar {
+        padding: var(--sl-spacing-x-small);
       }
 
       .flex-auto {
@@ -727,8 +766,7 @@ class Pages extends LitElement {
       }
 
       ${prefix} .mobile-header {
-        margin: 0.5rem;
-        margin-left: 1rem;
+        margin: var(--sl-spacing-x-small);
         align-items: center;
         display: flex;
         justify-content: space-between;
@@ -766,7 +804,11 @@ class Pages extends LitElement {
       >
         Pages in ${this.collInfo!.title}
       </div>
-      <div class="search-bar is-marginless">
+      <div
+        class="search-bar is-marginless ${this.isSidebar
+          ? "sidebar-search-bar"
+          : "main-search-bar"}"
+      >
         ${this.isSidebar
           ? html`<h3 class="is-sr-only">Search and Filter Pages</h3>`
           : ""}
@@ -830,13 +872,6 @@ class Pages extends LitElement {
             ? html`<fa-icon class="editIcon" .svg="${fasEdit}"></fa-icon>`
             : html``}
           ${this.renderSeedPagesFilter()}
-
-          <span
-            class="num-results is-hidden-mobile"
-            aria-live="polite"
-            aria-atomic="true"
-            >${this.renderPageCounts()}</span
-          >
           ${this.editable
             ? html` <div class="index-bar-actions">
                 ${this.renderDownloadMenu()}
@@ -978,7 +1013,7 @@ class Pages extends LitElement {
               @click="${this.onSort}"
               @keyup="${clickOnSpacebarPress}"
               data-key=""
-              class="column is-1 ${this.sortKey === ""
+              class="sort-control-label column is-1 ${this.sortKey === ""
                 ? this.sortDesc
                   ? "desc"
                   : "asc"
@@ -993,7 +1028,7 @@ class Pages extends LitElement {
           @click="${this.onSort}"
           @keyup="${clickOnSpacebarPress}"
           data-key="date"
-          class="column is-2 ${this.sortKey === "date"
+          class="sort-control-label column is-2 ${this.sortKey === "date"
             ? this.sortDesc
               ? "desc"
               : "asc"
@@ -1009,8 +1044,9 @@ class Pages extends LitElement {
           @click="${this.onSort}"
           @keyup="${clickOnSpacebarPress}"
           data-key="title"
-          class="column is-6 pagetitle ${this.query ? "is-5" : "is-6"} ${this
-            .sortKey === "title"
+          class="sort-control-label column is-6 pagetitle ${this.query
+            ? "is-5"
+            : "is-6"} ${this.sortKey === "title"
             ? this.sortDesc
               ? "desc"
               : "asc"
@@ -1020,10 +1056,6 @@ class Pages extends LitElement {
       </div>
 
       <div class="sorter is-hidden-tablet mobile-header">
-        <div class="num-results" aria-live="polite" aria-atomic="true">
-          ${this.renderPageCounts()}
-        </div>
-
         <wr-sorter
           id="pages"
           .sortKey="${this.sortKey}"
@@ -1108,9 +1140,7 @@ class Pages extends LitElement {
   renderPages() {
     //const name = this.currList === 0 ? "All Pages" : this.collInfo.lists[this.currList - 1].title;
     return html`
-      <div class="page-header has-text-weight-bold">
-        ${this.renderPageHeader()}
-      </div>
+      <div class="page-header">${this.renderPageHeader()}</div>
       <ul class="scroller" @scroll="${this.onScroll}">
         ${this.sortedPages.length
           ? html` ${this.sortedPages.map((p, i) => {
@@ -1136,6 +1166,15 @@ class Pages extends LitElement {
             })}`
           : html`<p class="mobile-header">${this.getNoResultsMessage()}</p>`}
       </ul>
+      <div
+        class="num-results ${this.isSidebar
+          ? "sidebar-num-results"
+          : "main-num-results"}"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        ${this.renderPaginationResults()}
+      </div>
     `;
   }
 
@@ -1326,21 +1365,29 @@ class Pages extends LitElement {
     this.requestUpdate();
   }
 
-  renderPageCounts() {
+  renderPaginationResults() {
     const collTotal = this.dynamicPagesQuery && this.collInfo?.pageCount;
     const filteredTotal = this.filteredPagesTotal;
     const total = collTotal || filteredTotal;
     const shown = this.sortedPages.length;
 
     const totalStr = `${total.toLocaleString()} ${
-      total === 1 ? "Page" : "Pages"
+      total === 1 ? "page" : "pages"
     }`;
+    const allShown = total === shown;
+    const countMsg = allShown
+      ? totalStr
+      : `${shown.toLocaleString()} of ${totalStr}`;
 
-    if (total === shown) {
-      return totalStr;
-    }
-
-    return `${shown.toLocaleString()} of ${totalStr}`;
+    return html`<span>${countMsg}</span>
+      ${allShown
+        ? nothing
+        : html`<span class="scroller-help-text">
+            Scroll for more
+            <span class="icon is-small">
+              <fa-icon .svg="${faArrowDown}" aria-hidden="true"></fa-icon>
+            </span>
+          </span>`} `;
   }
 
   renderSeedPagesFilter() {
@@ -1385,9 +1432,8 @@ class Pages extends LitElement {
     return "No Pages Found";
   }
 
-  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
-  async onScroll(event) {
-    const element = event.currentTarget;
+  async onScroll(event: Event) {
+    const element = event.currentTarget as HTMLUListElement;
     const diff =
       element.scrollHeight - element.scrollTop - element.clientHeight;
     if (diff < 40 && !this.skipScrollMore) {

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -522,14 +522,14 @@ class Pages extends LitElement {
         font-size: var(--sl-font-size-2x-small);
         font-weight: var(--sl-font-weight-semibold);
         color: var(--sl-color-neutral-500);
-        margin-bottom: var(--sl-spacing-x-small);
+        margin-bottom: var(--sl-spacing-2x-small);
         line-height: 1;
       }
 
       .index-bar-title {
         font-size: var(--sl-font-size-small);
         font-weight: var(--sl-font-weight-semibold);
-        margin-bottom: var(--sl-spacing-medium);
+        margin-bottom: var(--sl-spacing-small);
         word-break: break-word;
       }
 
@@ -563,6 +563,39 @@ class Pages extends LitElement {
         font-weight: normal;
         font-size: var(--sl-font-size-small);
         line-height: 1;
+      }
+
+      .seed-pages-filter {
+        font-size: var(--sl-font-size-small);
+      }
+
+      .seed-pages-filter .checkbox {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--sl-spacing-x-small);
+      }
+
+      .index-bar .seed-pages-filter {
+        margin-bottom: var(--sl-spacing-small);
+      }
+
+      .sorter {
+        gap: var(--sl-spacing-x-small);
+        align-items: center;
+      }
+
+      .sorter .num-results {
+        width: 100%;
+      }
+
+      .sorter wr-sorter {
+        flex-grow: 1;
+      }
+
+      .sorter .seed-pages-filter {
+        flex-shrink: 0;
+        font-weight: normal;
+        font-size: var(--sl-font-size-x-small);
       }
 
       .asc:after {
@@ -643,15 +676,11 @@ class Pages extends LitElement {
         border-bottom: 3px solid rgb(237, 237, 237);
       }
 
-      .check-select {
-        padding: 0 1em 0 0.5em;
-      }
-
       .search-bar {
         width: auto;
         display: flex;
         flex-direction: column;
-        padding: var(--sl-spacing-medium);
+        padding: var(--sl-spacing-small);
         background-color: var(--sl-color-neutral-100);
         border-bottom: 1px solid var(--sl-panel-border-color);
       }
@@ -662,6 +691,7 @@ class Pages extends LitElement {
 
       .index-bar-description {
         font-size: var(--sl-font-size-small);
+        margin-top: var(--sl-spacing-medium);
         margin-bottom: var(--sl-spacing-small);
         line-height: var(--sl-line-height-normal);
         flex: 1 1 auto;
@@ -799,27 +829,13 @@ class Pages extends LitElement {
           ${this.editable
             ? html`<fa-icon class="editIcon" .svg="${fasEdit}"></fa-icon>`
             : html``}
-          ${this.hasExtraPages
-            ? html` <span class="check-select">
-                <label class="checkbox">
-                  <input
-                    @change=${(e: Event) =>
-                      (this.showAllPages = (
-                        e.currentTarget as HTMLInputElement
-                      ).checked)}
-                    type="checkbox"
-                    .checked="${this.showAllPages}"
-                  />
-                  Show Non-Seed Pages
-                </label>
-              </span>`
-            : ""}
+          ${this.renderSeedPagesFilter()}
 
           <span
             class="num-results is-hidden-mobile"
             aria-live="polite"
             aria-atomic="true"
-            >${this.formatResults()}</span
+            >${this.renderPageCounts()}</span
           >
           ${this.editable
             ? html` <div class="index-bar-actions">
@@ -1003,10 +1019,11 @@ class Pages extends LitElement {
         >
       </div>
 
-      <div class="is-hidden-tablet mobile-header">
+      <div class="sorter is-hidden-tablet mobile-header">
         <div class="num-results" aria-live="polite" aria-atomic="true">
-          ${this.formatResults()}
+          ${this.renderPageCounts()}
         </div>
+
         <wr-sorter
           id="pages"
           .sortKey="${this.sortKey}"
@@ -1020,6 +1037,8 @@ class Pages extends LitElement {
           class="${this.filteredPages.length ? "" : "is-hidden"}"
         >
         </wr-sorter>
+
+        ${this.renderSeedPagesFilter()}
       </div>
     `;
   }
@@ -1307,7 +1326,7 @@ class Pages extends LitElement {
     this.requestUpdate();
   }
 
-  formatResults() {
+  renderPageCounts() {
     const collTotal = this.dynamicPagesQuery && this.collInfo?.pageCount;
     const filteredTotal = this.filteredPagesTotal;
     const total = collTotal || filteredTotal;
@@ -1322,6 +1341,22 @@ class Pages extends LitElement {
     }
 
     return `${shown.toLocaleString()} of ${totalStr}`;
+  }
+
+  renderSeedPagesFilter() {
+    if (!this.hasExtraPages) return;
+
+    return html`<div class="seed-pages-filter check-select">
+      <label class="checkbox">
+        <input
+          @change=${(e: Event) =>
+            (this.showAllPages = (e.currentTarget as HTMLInputElement).checked)}
+          type="checkbox"
+          .checked="${this.showAllPages}"
+        />
+        Show Non-Seed Pages
+      </label>
+    </div>`;
   }
 
   getNoResultsMessage() {

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -592,7 +592,7 @@ class Pages extends LitElement {
       }
 
       .seed-pages-filter .checkbox {
-        display: inline-flex;
+        display: flex;
         align-items: center;
         gap: var(--sl-spacing-x-small);
       }

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -1,7 +1,7 @@
 "use strict";
 
 import { LitElement, html, css, unsafeCSS, type PropertyValues } from "lit";
-import { property } from "lit/decorators.js";
+import { property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { wrapCss, clickOnSpacebarPress } from "./misc";
 import ndjson from "fetch-ndjson";
@@ -110,13 +110,13 @@ class Pages extends LitElement {
   dynamicPagesQuery = false;
 
   @property({ type: Number })
-  totalPages = 0;
-
-  @property({ type: Number })
   dynamicPageCount = 1;
 
   @property({ type: Boolean })
   skipScrollMore = false;
+
+  @state()
+  private filteredPagesTotal = 0;
 
   private _ival: number | undefined;
 
@@ -222,7 +222,10 @@ class Pages extends LitElement {
     }
     this.loading = true;
     if (this.flex && this.query && this.textPages) {
-      const results = await this.flex.searchAsync(this.query, 25);
+      const results = await this.flex.searchAsync(
+        this.query,
+        DYNAMIC_PAGE_SIZE,
+      );
       this.filteredPages = results.map(
         (inx: Id) => this.textPages![inx as number],
       );
@@ -232,7 +235,7 @@ class Pages extends LitElement {
       this.filteredPages = [...this.collInfo!.pages];
     }
 
-    this.totalPages = this.filteredPages.length;
+    this.filteredPagesTotal = this.filteredPages.length;
 
     if (this.dynamicPagesQuery) {
       if (!this.query) {
@@ -347,7 +350,7 @@ class Pages extends LitElement {
       this.filteredPages = [...this.filteredPages, ...newPages];
     }
 
-    this.totalPages = this.filteredPages.length;
+    this.filteredPagesTotal = this.filteredPages.length;
   }
 
   async filterCurated() {
@@ -369,10 +372,7 @@ class Pages extends LitElement {
     );
   }
 
-  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'pages' implicitly has an 'any' type.
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
-  addPages(pages) {
+  async addPages(pages: Page[]) {
     const flex = new FlexIndex();
 
     this.flex = flex;
@@ -380,8 +380,7 @@ class Pages extends LitElement {
 
     if (!this.dynamicPagesQuery) {
       this.hasExtraPages = Boolean(
-        this.textPages &&
-          this.collInfo?.pages &&
+        this.collInfo?.pages &&
           this.textPages.length > this.collInfo.pages.length,
       );
     }
@@ -391,10 +390,7 @@ class Pages extends LitElement {
     }
 
     return Promise.all(
-      // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'page' implicitly has an 'any' type. | TS7006 - Parameter 'index' implicitly has an 'any' type.
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line @typescript-eslint/promise-function-async
-      pages.map((page, index) => {
+      pages.map(async (page, index) => {
         let text = page.url;
         if (page.title) {
           text += " " + page.title;
@@ -402,8 +398,6 @@ class Pages extends LitElement {
         if (page.text) {
           text += " " + page.text;
         }
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         return flex.addAsync(index, text);
       }),
     );
@@ -433,7 +427,7 @@ class Pages extends LitElement {
         }
       }
 
-      const lines: unknown[] = [];
+      const lines: Page[] = [];
 
       for await (const line of ndjson(resp.body!.getReader())) {
         if (!line.url) {
@@ -445,7 +439,7 @@ class Pages extends LitElement {
         if (typeof line.ts === "string") {
           line.ts = new Date(line.ts as string).getTime();
         }
-        lines.push(line);
+        lines.push(line as unknown as Page);
       }
 
       await this.addPages(lines);
@@ -1018,7 +1012,9 @@ class Pages extends LitElement {
           .sortDesc="${this.sortDesc}"
           .sortKeys="${Pages.sortKeys}"
           .data="${this.filteredPages}"
-          .pageResults="${this.dynamicPagesQuery ? this.totalPages : 100}"
+          .pageResults="${this.dynamicPagesQuery
+            ? this.filteredPagesTotal
+            : 100}"
           @sort-changed="${this.onSortChanged}"
           class="${this.filteredPages.length ? "" : "is-hidden"}"
         >
@@ -1311,12 +1307,16 @@ class Pages extends LitElement {
   }
 
   formatResults() {
-    const length = this.totalPages;
-    if (length === this.sortedPages.length) {
-      return `${length} Page${length !== 1 ? "s" : ""}`;
-    } else {
-      return `${this.sortedPages.length} of ${length} Pages Shown`;
+    const collTotal = this.dynamicPagesQuery && this.collInfo?.pageCount;
+    const filteredTotal = this.filteredPagesTotal;
+    const total = collTotal || filteredTotal;
+    const shown = this.sortedPages.length;
+
+    if (total === shown) {
+      return `${total} ${total === 1 ? "Page" : "Pages"}`;
     }
+
+    return `${shown} of ${total} Pages Shown`;
   }
 
   getNoResultsMessage() {

--- a/src/sorter.ts
+++ b/src/sorter.ts
@@ -118,6 +118,10 @@ class Sorter<T = unknown> extends LitElement {
       button.button.is-small {
         border-radius: 4px;
       }
+
+      .is-small {
+        font-size: var(--sl-font-size-x-small);
+      }
     `);
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,7 @@ export type ItemType = {
   totalSize?: unknown;
   size?: number | string;
   canQueryPages?: boolean;
+  pageCount?: number;
 };
 
 export type FavIconEventDetail = {

--- a/src/url-resources.ts
+++ b/src/url-resources.ts
@@ -277,9 +277,20 @@ class URLResources extends LitElement {
         width: 100% !important;
       }
 
-      .notification {
+      .search-bar {
         width: 100%;
+        background-color: var(--sl-color-neutral-100);
+        border-bottom: 1px solid var(--sl-panel-border-color);
       }
+
+      .main-search-bar {
+        padding: var(--sl-spacing-small);
+      }
+
+      .sidebar-search-bar {
+        padding: var(--sl-spacing-x-small);
+      }
+
       .all-results {
         margin: 0 0 0 0.5em;
         display: flex;
@@ -362,7 +373,11 @@ class URLResources extends LitElement {
       >
         Search and Filter
       </div>
-      <div class="notification level is-marginless">
+      <div
+        class="search-bar level is-marginless ${this.isSidebar
+          ? "sidebar-search-bar"
+          : "main-search-bar"}"
+      >
         <div class="level-left flex-auto">
           <div class="level-item flex-auto">
             <span class="is-hidden-mobile">Search:&nbsp;&nbsp;</span>


### PR DESCRIPTION
Fixes https://github.com/webrecorder/replayweb.page/issues/523
Resolves https://github.com/webrecorder/replayweb.page/issues/396

## Changes
- Fixes incorrect page count shown
- Enables non-seed pages by default
- Improves UX and accessibility of scrolling to load more by displaying help text

## Screenshots

<img width="1090" height="480" alt="Screenshot 2026-06-04 at 1 54 25 PM" src="https://github.com/user-attachments/assets/6bbae3fe-6f7f-4e85-9e5b-982a62ae4153" />

<img width="1089" height="527" alt="Screenshot 2026-06-04 at 1 54 44 PM" src="https://github.com/user-attachments/assets/17a1119f-dd2d-47dd-afce-2bca4af27578" />

## Follow-ups/caveats

- The page count may still be inaccurate if `pageCount` is not returned in the collection. We may want to add a separate page count total that is consistently present for all WACZs moving forward (cc @ikreymer )
- The resources sidebar still results the wrong number of results since the API doesn't currently return a total for resources and will need a backend change to include the total in the WACZ (cc @ikreymer )