### PR TITLE
feat: Update styles and allow customizing parts

### DIFF
--- a/src/appmain.ts
+++ b/src/appmain.ts
@@ -261,6 +261,24 @@ export class ReplayWebApp extends LitElement {
         margin: 15px;
       }
 
+      .about-dialog-header {
+        display: flex;
+      }
+
+      .about-dialog h3,
+      h4 {
+        font-weight: var(--sl-font-weight-bold);
+        margin-bottom: var(--sl-spacing-x-small);
+      }
+
+      .about-dialog p + p {
+        margin-top: 1em;
+      }
+
+      .about-dialog details p {
+        font-size: var(--sl-font-size-x-small);
+      }
+
       @media screen and (min-width: 840px) {
         .menu-only {
           display: none;
@@ -502,7 +520,7 @@ export class ReplayWebApp extends LitElement {
     return html`
       ${!this.embed || this.embed === "full" ? this.renderNavBar() : ""}
       ${this.sourceUrl ? this.renderColl() : this.renderHomeIndex()}
-      ${this.showAbout ? this.renderAbout() : ""}
+      ${this.renderAbout()}
       ${this.showFileDropOverlay ? this.renderDropFileOverlay() : ""}
     `;
   }
@@ -785,91 +803,95 @@ export class ReplayWebApp extends LitElement {
   }
 
   renderAbout() {
-    return html`
-      <div class="modal is-active">
-        <div class="modal-background" @click="${this.onAboutClose}"></div>
-          <div class="modal-card">
-            <header class="modal-card-head">
-              <p class="modal-card-title">About ReplayWeb.page ${
-                IS_APP ? "App" : ""
-              }</p>
-              <button class="delete" aria-label="close" @click="${
-                this.onAboutClose
-              }"></button>
-            </header>
-            <section class="modal-card-body">
-              <div class="container">
-                <div class="content">
-                  <div style="display: flex">
-                    <div class="has-text-centered" style="width: 220px">
-                      <fa-icon
-                        size="3rem"
-                        .svg=${rwpLogo}
-                        aria-label="ReplayWeb.page Logo"
-                        role="img"
-                      ></fa-icon>
-                      <div style="font-size: smaller; margin-bottom: 1em">${
-                        IS_APP ? "App" : ""
-                      } v${VERSION}</div>
-                    </div>
-
-                    ${
-                      IS_APP
-                        ? html`
-                            <p>
-                              ReplayWeb.page App is a standalone app for Mac,
-                              Windows and Linux that loads web archive files
-                              provided by the user and renders them for replay.
-                            </p>
-                          `
-                        : html` <p>
-                            <a href="https://replayweb.page" target="_blank"
-                              >ReplayWeb.page</a
-                            >
-                            is a browser-based viewer that loads web archive
-                            files provided by the user and renders them for
-                            replay in the browser.
-                          </p>`
-                    }
-                  </div>
-
-                  <p>Full source code is available 
-                    <a href="https://github.com/webrecorder/replayweb.page" target="_blank">on GitHub</a>.
-                  </p>
-
-                  <p>See the <a target="_blank" href="./docs">documentation</a> for more info on how it works.</p>
-
-                  <p>ReplayWeb.page is developed by <a href="https://webrecorder.net/" target="_blank">Webrecorder</a>.</p>
-
-                  <h3>Privacy</h3>
-                  <p><b>No data is uploaded anywhere and no information is collected.</b></p>
-                  <p>All content rendered stays directly in your browser.<br/>When loading an archive from Google Drive,
-                  the site may ask for account authorization to download the specified file only.</p>
-
-                  <h4>Disclaimer of Warranties</h4>
-                  <p>The application is provided "as is" without any guarantees.</p>
-                  <details>
-                    <summary>Legalese:</summary>
-                    <p style="font-size: 0.8rem">DISCLAIMER OF SOFTWARE WARRANTY. WEBRECORDER SOFTWARE PROVIDES THIS SOFTWARE TO YOU "AS AVAILABLE"
-                    AND WITHOUT WARRANTY OF ANY KIND, EXPRESS, IMPLIED OR OTHERWISE,
-                    INCLUDING WITHOUT LIMITATION ANY WARRANTY OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.</p>
-                  </details>
-                  <div class="has-text-centered">
-                    <a class="button is-warning" href="#" @click="${
-                      this.onAboutClose
-                    }">Close</a>
-                  </div>
-                </div>
-              </div>
-            </section>
+    return html` <sl-dialog
+      class="about-dialog"
+      label=${`About ReplayWeb.page ${IS_APP ? "App" : ""}`}
+      ?open=${this.showAbout}
+      @sl-after-hide=${this.onAboutClose}
+    >
+      <div class="about-dialog-header">
+        <div class="has-text-centered" style="width: 220px">
+          <fa-icon
+            size="3rem"
+            .svg=${rwpLogo}
+            aria-label="ReplayWeb.page Logo"
+            role="img"
+          ></fa-icon>
+          <div style="font-size: smaller; margin-bottom: 1em">
+            ${IS_APP ? "App" : ""} v${VERSION}
           </div>
         </div>
-      </div>`;
+
+        ${IS_APP
+          ? html`
+              <p>
+                ReplayWeb.page App is a standalone app for Mac, Windows and
+                Linux that loads web archive files provided by the user and
+                renders them for replay.
+              </p>
+            `
+          : html` <p>
+              <a href="https://replayweb.page" target="_blank"
+                >ReplayWeb.page</a
+              >
+              is a browser-based viewer that loads web archive files provided by
+              the user and renders them for replay in the browser.
+            </p>`}
+      </div>
+
+      <p>
+        Full source code is available
+        <a href="https://github.com/webrecorder/replayweb.page" target="_blank"
+          >on GitHub</a
+        >.
+      </p>
+
+      <p>
+        See the <a target="_blank" href="./docs">documentation</a> for more info
+        on how it works.
+      </p>
+
+      <p>
+        ReplayWeb.page is developed by
+        <a href="https://webrecorder.net/" target="_blank">Webrecorder</a>.
+      </p>
+
+      <sl-divider></sl-divider>
+      <h3>Privacy</h3>
+      <p>No data is uploaded anywhere and no information is collected.</p>
+      <details>
+        <summary>More info</summary>
+        <p>
+          All content rendered stays directly in your browser.<br />When loading
+          an archive from Google Drive, the site may ask for account
+          authorization to download the specified file only.
+        </p>
+      </details>
+      <sl-divider></sl-divider>
+      <h4>Disclaimer of Warranties</h4>
+      <p>The application is provided "as is" without any guarantees.</p>
+      <details>
+        <summary>Legal</summary>
+        <p>
+          DISCLAIMER OF SOFTWARE WARRANTY. WEBRECORDER SOFTWARE PROVIDES THIS
+          SOFTWARE TO YOU "AS AVAILABLE" AND WITHOUT WARRANTY OF ANY KIND,
+          EXPRESS, IMPLIED OR OTHERWISE, INCLUDING WITHOUT LIMITATION ANY
+          WARRANTY OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+        </p>
+      </details>
+      <sl-button
+        slot="footer"
+        variant="primary"
+        size="small"
+        @click="${this.onAboutClose}"
+        >Close</sl-button
+      >
+    </sl-dialog>`;
   }
 
-  onAboutClose() {
+  readonly onAboutClose = () => {
     this.showAbout = false;
-  }
+  };
 
   renderDropFileOverlay() {
     return html`

--- a/src/appmain.ts
+++ b/src/appmain.ts
@@ -452,6 +452,15 @@ export class ReplayWebApp extends LitElement {
       @coll-loaded=${this.onCollLoaded}
       @coll-load-cancel=${this.onCollLoadCancel}
       @about-show=${() => (this.showAbout = true)}
+      exportparts="
+       replay-bar:wr-item__replay-bar,
+       replay-bar-container:wr-item__replay-bar-container,
+       replay-bar-input:wr-item__replay-bar-input,
+       replay-content:wr-item__replay-content,
+       replay-tabs-nav:wr-item__replay-tabs-nav,
+       replay-tabs-panel:wr-item__replay-tabs-panel,
+       replay-main:wr-item__replay-main,
+     "
     ></wr-item>`;
   }
 

--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -1,6 +1,7 @@
 @charset "utf-8";
 
 @import "@shoelace-style/shoelace/dist/themes/light.css";
+@import "./shoelace.scss";
 
 /*$wr-green: #64e986;*/
 $wr-green: #55be6f;
@@ -152,10 +153,19 @@ a:focus {
   border-width: 0;
 }
 
+// Update size of small icons in controls
 .control.has-icons-left .icon.is-small, .control.has-icons-right .icon.is-small {
   margin-top: 1px;
-  margin-left: 1px;
   width: 2rem;
   height: 2rem;
   font-size: var(--sl-font-size-medium);
 }
+
+.control.has-icons-left .icon.is-small {
+  margin-left: 1px;
+}
+
+.control.has-icons-right .icon.is-small {
+  margin-right: 1px;
+}
+

--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -151,3 +151,11 @@ a:focus {
   white-space: nowrap;
   border-width: 0;
 }
+
+.control.has-icons-left .icon.is-small, .control.has-icons-right .icon.is-small {
+  margin-top: 1px;
+  margin-left: 1px;
+  width: 2rem;
+  height: 2rem;
+  font-size: var(--sl-font-size-medium);
+}

--- a/src/assets/shoelace.scss
+++ b/src/assets/shoelace.scss
@@ -1,0 +1,23 @@
+sl-dialog {
+  --header-spacing: var(--sl-spacing-small);
+  --body-spacing: var(--sl-spacing-small);
+  --footer-spacing: var(--sl-spacing-small);
+  --width: 40rem;
+}
+
+sl-dialog::part(header) {
+  border-bottom: 1px solid var(--sl-panel-border-color);
+}
+
+sl-dialog::part(title) {
+  font-size: var(--sl-font-size-medium);
+  font-weight: var(--sl-font-weight-bold);
+}
+
+sl-dialog::part(body) {
+  font-size: var(--sl-font-size-small);
+}
+
+sl-dialog::part(footer) {
+  border-top: 1px solid var(--sl-panel-border-color);
+}

--- a/src/components/icon.ts
+++ b/src/components/icon.ts
@@ -28,6 +28,9 @@ export class Icon extends LitElement {
   @property({ type: String })
   svg?: string;
 
+  @property({ type: String, reflect: true })
+  ariaHidden = "true";
+
   render() {
     if (!this.svg) {
       return;

--- a/src/components/labeled-field.ts
+++ b/src/components/labeled-field.ts
@@ -6,21 +6,6 @@ import faClone from "@fortawesome/fontawesome-free/svgs/regular/clone.svg";
 import faCheck from "@fortawesome/fontawesome-free/svgs/solid/check.svg";
 import faX from "@fortawesome/fontawesome-free/svgs/solid/times.svg";
 
-import { registerIconLibrary } from "@shoelace-style/shoelace/dist/utilities/icon-library.js";
-
-import systemLibrary from "@shoelace-style/shoelace/dist/components/icon/library.system.js";
-
-// disable system library to prevent loading of unused data: URLs
-// allow only "x-lg" as it is needed for sl-dialog
-registerIconLibrary("system", {
-  resolver: (name) => {
-    if (name === "x-lg") {
-      return systemLibrary.resolver(name);
-    }
-    return "";
-  },
-});
-
 @customElement("wr-labeled-field")
 class LabeledField extends LitElement {
   @property({ type: String })

--- a/src/embed-receipt.ts
+++ b/src/embed-receipt.ts
@@ -3,7 +3,8 @@ import webrecorderLockupColor from "~assets/brand/webrecorder-lockup-color.svg";
 import btAngleDoubleDown from "~assets/icons/chevron-double-down.svg";
 import btAngleDoubleUp from "~assets/icons/chevron-double-up.svg";
 import fabGithub from "@fortawesome/fontawesome-free/svgs/brands/github.svg";
-import fasDownload from "@fortawesome/fontawesome-free/svgs/solid/download.svg";
+
+import iconDownload from "~icons/download.svg";
 
 import { clickOnSpacebarPress } from "./misc";
 
@@ -246,11 +247,7 @@ export class RWPEmbedReceipt extends LitElement {
                     @keyup="${clickOnSpacebarPress}"
                   >
                     <span class="icon is-small">
-                      <fa-icon
-                        size="1.0em"
-                        aria-hidden="true"
-                        .svg="${fasDownload}"
-                      ></fa-icon>
+                      <wr-icon .svg="${iconDownload}"></wr-icon>
                     </span>
                     <span>Download Archive</span>
                   </a>

--- a/src/item-index.ts
+++ b/src/item-index.ts
@@ -5,7 +5,7 @@ import { wrapCss, apiPrefix } from "./misc";
 import fasArrowUp from "@fortawesome/fontawesome-free/svgs/solid/angle-double-up.svg";
 import fasArrowDown from "@fortawesome/fontawesome-free/svgs/solid/angle-double-down.svg";
 
-import fasSearch from "@fortawesome/fontawesome-free/svgs/solid/search.svg";
+import iconSearch from "~icons/search.svg";
 
 import type { ItemType } from "./types";
 
@@ -306,7 +306,7 @@ class ItemIndex extends LitElement {
                       placeholder="Search by Archive Title or Source"
                     />
                     <span class="icon is-left is-small">
-                      <fa-icon .svg="${fasSearch}"></fa-icon>
+                      <wr-icon .svg="${iconSearch}"></wr-icon>
                     </span>
                   </div>
                   <wr-sorter

--- a/src/item.ts
+++ b/src/item.ts
@@ -24,14 +24,6 @@ import {
   getDateFromTS,
 } from "./pageutils";
 
-import fasTriangleExclamation from "@fortawesome/fontawesome-free/svgs/solid/exclamation-triangle.svg";
-import fasBook from "@fortawesome/fontawesome-free/svgs/solid/book.svg";
-
-import farResources from "@fortawesome/fontawesome-free/svgs/solid/puzzle-piece.svg";
-import farPages from "@fortawesome/fontawesome-free/svgs/regular/file-image.svg";
-
-import fasCaretDown from "@fortawesome/fontawesome-free/svgs/solid/caret-down.svg";
-
 import iconArrowClockwise from "~icons/arrow-clockwise.svg";
 import iconArrowLeft from "~icons/arrow-left.svg";
 import iconArrowRight from "~icons/arrow-right.svg";
@@ -39,10 +31,15 @@ import iconArrowRepeat from "~icons/arrow-repeat.svg";
 import iconArrowsExpandVertical from "~icons/arrows-expand-vertical.svg";
 import iconArrowBarLeft from "~icons/arrow-bar-left.svg";
 import iconArrowsFullscreen from "~icons/arrows-fullscreen.svg";
+import iconBook from "~icons/book.svg";
+import iconChevronDown from "~icons/chevron-down.svg";
+import iconExclamationTriangle from "~icons/exclamation-triangle.svg";
 import iconInfoSquare from "~icons/info-square.svg";
 import iconDownload from "~icons/download.svg";
 import iconExitFullscreen from "~icons/fullscreen-exit.svg";
+import iconFileRichtextFill from "~icons/file-richtext-fill.svg";
 import iconLayoutSidebar from "~icons/layout-sidebar.svg";
+import iconPuzzleFill from "~icons/puzzle-fill.svg";
 import iconThreeDotsVertical from "~icons/three-dots-vertical.svg";
 
 import { RWPEmbedReceipt } from "./embed-receipt";
@@ -674,6 +671,10 @@ class Item extends LitElement {
         border-color: var(--sl-color-neutral-400);
       }
 
+      .tab .icon {
+        font-size: var(--sl-font-size-medium);
+      }
+
       .tab-label {
         display: inline;
         font-weight: var(--sl-font-weight-semibold);
@@ -904,6 +905,7 @@ class Item extends LitElement {
 
       .timestamp-count-badge {
         display: inline-flex;
+        align-items: center;
         gap: var(--sl-spacing-2x-small);
         background-color: var(--sl-color-blue-500);
         color: var(--sl-color-neutral-0);
@@ -911,15 +913,20 @@ class Item extends LitElement {
         padding: var(--sl-spacing-3x-small) var(--sl-spacing-x-small);
         border-radius: var(--sl-border-radius-small);
         transition: background-color var(--sl-transition-fast);
+        height: 1rem;
+        font-size: var(--sl-font-size-x-small);
       }
 
       .timestamp-count {
         font-weight: 600;
-        transform: translateY(0.075em);
       }
 
       .timestamp-menu-item {
         font-variant-numeric: tabular-nums;
+      }
+
+      .timestamp-menu-item::part(label) {
+        font-size: var(--sl-font-size-small);
       }
 
       .timestamp-menu-item[aria-selected="true"]::part(label) {
@@ -1037,7 +1044,7 @@ class Item extends LitElement {
         right: 8px;
       }
 
-      .sidebar-nav-toggle[aria-selected="true"] {
+      .sidebar-nav-toggle:not([disabled])[aria-selected="true"] {
         color: var(--internal-bar-active-text-color);
       }
 
@@ -1174,11 +1181,7 @@ class Item extends LitElement {
                 )}"
               >
                 <span class="icon"
-                  ><fa-icon
-                    .svg="${fasBook}"
-                    aria-hidden="true"
-                    title="Story"
-                  ></fa-icon
+                  ><wr-icon .svg="${iconBook}" title="Story"></wr-icon
                 ></span>
                 <span
                   class="tab-label ${isSidebar ? "is-hidden" : ""}"
@@ -1205,11 +1208,7 @@ class Item extends LitElement {
             )}"
           >
             <span class="icon"
-              ><fa-icon
-                .svg="${farPages}"
-                aria-hidden="true"
-                title="Pages"
-              ></fa-icon
+              ><wr-icon .svg="${iconFileRichtextFill}" title="Pages"></wr-icon
             ></span>
             <span class="tab-label" title="Pages">Pages</span>
           </a>
@@ -1231,11 +1230,7 @@ class Item extends LitElement {
             )}"
           >
             <span class="icon"
-              ><fa-icon
-                .svg="${farResources}"
-                aria-hidden="true"
-                title="Resources"
-              ></fa-icon
+              ><wr-icon .svg="${iconPuzzleFill}" title="Resources"></wr-icon
             ></span>
             <span class="tab-label" title="Resources">Resources</span>
           </a>
@@ -1552,12 +1547,7 @@ class Item extends LitElement {
             : nothing}
           <sl-divider></sl-divider>
           <sl-menu-item @click="${this.onAbout}">
-            <fa-icon
-              slot="prefix"
-              size="1.0rem"
-              aria-hidden="true"
-              .svg=${rwpIcon}
-            ></fa-icon>
+            <wr-icon slot="prefix" .svg=${rwpIcon}></wr-icon>
             About ${this.appName}
             <span slot="suffix" class="menu-version">${this.appVersion}</span>
           </sl-menu-item>
@@ -1599,7 +1589,7 @@ class Item extends LitElement {
                 <div>${currDateStr}</div>
                 <div class="timestamp-count-badge">
                   <div class="timestamp-count">${timestampStrs.length}</div>
-                  <fa-icon .svg="${fasCaretDown}" aria-hidden="true"></fa-icon>
+                  <wr-icon .svg="${iconChevronDown}"></wr-icon>
                 </div>
               </button>
               <sl-menu @sl-select=${this.onSelectTimestamp}>
@@ -1668,11 +1658,7 @@ class Item extends LitElement {
   renderItemInfo() {
     if (!this.itemInfo)
       return html`<sl-alert open variant="warning">
-        <fa-icon
-          slot="icon"
-          .svg=${fasTriangleExclamation}
-          aria-hidden="true"
-        ></fa-icon>
+        <wr-icon slot="icon" .svg=${iconExclamationTriangle}></wr-icon>
         <strong>Archive info is not available</strong><br />
         Please reload and try again.
       </sl-alert>`;

--- a/src/item.ts
+++ b/src/item.ts
@@ -115,6 +115,10 @@ export type TabData = EmbedReplayData & {
  * @cssPart replay-bar
  * @cssPart replay-bar-container
  * @cssPart replay-bar-input
+ * @cssPart replay-content
+ * @cssPart replay-tabs-nav
+ * @cssPart replay-tabs-panel
+ * @cssPart replay-main
  * @cssProperty rwp-bar-background-color
  * @cssProperty rwp-bar-text-color
  * @cssProperty rwp-bar-button-color
@@ -688,10 +692,12 @@ class Item extends LitElement {
         flex-direction: row;
         margin-bottom: 0px;
         overflow: unset;
+        border-bottom: 1px solid var(--sl-panel-border-color);
       }
 
       .main.tabs ul {
         position: relative;
+        border-bottom: 0;
       }
 
       .main.tabs:not(.sidebar) ul {
@@ -1060,7 +1066,7 @@ class Item extends LitElement {
             >Close</sl-button
           >
         </sl-dialog>
-        <div id="tabContents">
+        <div id="tabContents" part="replay-content">
           <div
             id="contents"
             class="is-light ${isSidebar
@@ -1078,6 +1084,7 @@ class Item extends LitElement {
           ${isReplay && this.isVisible
             ? html`
                 <wr-coll-replay
+                  part="replay-main"
                   role="main"
                   .collInfo="${this.itemInfo}"
                   sourceUrl="${this.sourceUrl || ""}"
@@ -1090,6 +1097,11 @@ class Item extends LitElement {
                   @replay-favicons="${this.onFavIcons}"
                   @cancel-click-download="${() =>
                     (this.clickToDownloadMode = false)}"
+                  exportparts="
+                    iframe:wr-coll-replay__iframe,
+                    iframe-container:wr-coll-replay__iframe-container,
+                    iframe-page-not-found:wr-coll-replay__iframe-page-not-found,
+                  "
                 >
                 </wr-coll-replay>
               `
@@ -1108,6 +1120,7 @@ class Item extends LitElement {
     // }
 
     return html` <nav
+      part="replay-tabs-nav"
       class="main tabs is-centered ${isSidebar ? "sidebar" : ""}"
       aria-label="tabs"
     >
@@ -1689,6 +1702,7 @@ class Item extends LitElement {
     return html`
       ${isStory
         ? html` <wr-coll-story
+            part="replay-tabs-panel"
             .collInfo="${this.itemInfo || {}}"
             .active="${isStory}"
             currList="${this.tabData.currList || 0}"
@@ -1706,6 +1720,7 @@ class Item extends LitElement {
         : ""}
       ${isResources
         ? html` <wr-coll-resources
+            part="replay-tabs-panel"
             .collInfo="${this.itemInfo || {}}"
             .active="${isResources}"
             query="${this.tabData.query || ""}"
@@ -1725,6 +1740,7 @@ class Item extends LitElement {
         : ""}
       ${isPages
         ? html` <wr-page-view
+            part="replay-tabs-panel"
             .collInfo="${this.itemInfo}"
             .active="${isPages}"
             .editable="${this.editable}"

--- a/src/item.ts
+++ b/src/item.ts
@@ -35,13 +35,13 @@ import farPages from "@fortawesome/fontawesome-free/svgs/regular/file-image.svg"
 import fasInfoIcon from "@fortawesome/fontawesome-free/svgs/solid/info-circle.svg";
 import fasSync from "@fortawesome/fontawesome-free/svgs/solid/sync-alt.svg";
 
-import faExpandAlt from "@fortawesome/fontawesome-free/svgs/solid/expand-alt.svg";
-import faCompressAlt from "@fortawesome/fontawesome-free/svgs/solid/compress-alt.svg";
 import fasCaretDown from "@fortawesome/fontawesome-free/svgs/solid/caret-down.svg";
 
 import iconArrowClockwise from "~icons/arrow-clockwise.svg";
 import iconArrowLeft from "~icons/arrow-left.svg";
 import iconArrowRight from "~icons/arrow-right.svg";
+import iconArrowsExpandVertical from "~icons/arrows-expand-vertical.svg";
+import iconArrowBarLeft from "~icons/arrow-bar-left.svg";
 import iconArrowsFullscreen from "~icons/arrows-fullscreen.svg";
 import iconExitFullscreen from "~icons/fullscreen-exit.svg";
 import iconLayoutSidebar from "~icons/layout-sidebar.svg";
@@ -814,6 +814,10 @@ class Item extends LitElement {
         font-size: var(--sl-font-size-small);
       }
 
+      .replay-bar .icon {
+        font-size: 1.125rem;
+      }
+
       .favicon img {
         width: 20px;
         height: 20px;
@@ -1017,14 +1021,6 @@ class Item extends LitElement {
       .sidebar-nav:hover span.nav-hover,
       .sidebar-nav:focus-within span.nav-hover {
         display: initial;
-        color: rgb(72, 118, 255);
-      }
-
-      .sidebar-nav fa-icon {
-        vertical-align: bottom;
-      }
-
-      .sidebar-nav:hover fa-icon {
         color: rgb(72, 118, 255);
       }
 
@@ -1246,11 +1242,11 @@ class Item extends LitElement {
                 class="is-marginless is-size-6 is-paddingless"
               >
                 <span class="is-sr-only">Expand Sidebar to Full View</span>
-                <fa-icon
+                <wr-icon
                   title="Expand"
-                  .svg="${faExpandAlt}"
+                  .svg="${iconArrowsExpandVertical}"
                   aria-hidden="true"
-                ></fa-icon>
+                ></wr-icon>
               </a>
             </li>`
           : this.tabDataBeforeFullView
@@ -1263,11 +1259,11 @@ class Item extends LitElement {
                 class="is-marginless is-size-6 is-paddingless"
               >
                 <span class="is-sr-only">Go Back to Split View</span>
-                <fa-icon
+                <wr-icon
                   title="Contract"
-                  .svg="${faCompressAlt}"
+                  .svg="${iconArrowBarLeft}"
                   aria-hidden="true"
-                ></fa-icon>
+                ></wr-icon>
               </a>
             </li>`
           : nothing}

--- a/src/item.ts
+++ b/src/item.ts
@@ -648,12 +648,26 @@ class Item extends LitElement {
         line-height: 0.5em;
       }
 
-      li.is-active {
-        font-weight: bold;
+      .tab {
+        font-size: var(--sl-font-size-small);
+      }
+
+      .tab a {
+        border-color: transparent;
+        color: var(--sl-color-neutral-700);
+        border-width: 2px;
+        padding: var(--sl-spacing-x-small) 0;
+        margin-top: 1px;
+      }
+
+      .tab:hover a {
+        border-color: var(--sl-color-neutral-400);
       }
 
       .tab-label {
         display: inline;
+        font-weight: var(--sl-font-weight-semibold);
+        padding-right: var(--sl-spacing-x-small);
       }
 
       @media screen and (max-width: ${!IS_APP ? css`1053px` : css`1163px`}) {
@@ -677,21 +691,12 @@ class Item extends LitElement {
         position: relative;
       }
 
-      .main.tabs li {
-        line-height: 1.5;
-        padding: 6px 0 4px 0;
+      .main.tabs:not(.sidebar) ul {
+        gap: var(--sl-spacing-large);
       }
 
-      @media screen and (max-width: 319px) {
-        .main.tabs li a {
-          padding-right: 4px;
-          padding-left: 4px;
-        }
-      }
-
-      .sidebar.main.tabs li a {
-        padding-right: 6px;
-        padding-left: 6px;
+      .main.tabs.sidebar ul {
+        gap: var(--sl-spacing-small);
       }
 
       #contents {
@@ -1115,14 +1120,13 @@ class Item extends LitElement {
           : ""}
 
         <li
-          class="${this.tabData.view === EmbedReplayDataView.Pages
+          class="tab ${this.tabData.view === EmbedReplayDataView.Pages
             ? "is-active"
             : ""}"
         >
           <a
             @click="${this.onTabClick}"
             href="#pages"
-            class="is-size-6"
             aria-label="Pages"
             aria-current="${ifDefined(
               this.tabData.view === EmbedReplayDataView.Pages
@@ -1142,14 +1146,13 @@ class Item extends LitElement {
         </li>
 
         <li
-          class="${this.tabData.view === EmbedReplayDataView.Resources
+          class="tab ${this.tabData.view === EmbedReplayDataView.Resources
             ? "is-active"
             : ""}"
         >
           <a
             @click="${this.onTabClick}"
             href="#resources"
-            class="is-size-6"
             aria-label="URLs"
             aria-current="${ifDefined(
               this.tabData.view === EmbedReplayDataView.Resources

--- a/src/item.ts
+++ b/src/item.ts
@@ -418,7 +418,7 @@ class Item extends LitElement {
 
           minSize: [300, 300],
 
-          gutterSize: 4,
+          gutterSize: 14,
 
           onDragStart() {
             replay.setDisablePointer(true);
@@ -952,10 +952,31 @@ class Item extends LitElement {
         margin: 0 0 0 0.5em;
       }
 
+      .gutter {
+        --internal-gutter-background-color: var(
+          --rwp-gutter-background-color,
+          var(--sl-color-neutral-0)
+        );
+        --internal-gutter-border: var(
+          --rwp-gutter-border,
+          1px solid var(--sl-panel-border-color)
+        );
+        --internal-gutter-handle: var(
+          --rwp-gutter-handle,
+          url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAeCAYAAADkftS9AAAAIklEQVQoU2M4c+bMfxAGAgYYmwGrIIiDjrELjpo5aiZeMwF+yNnOs5KSvgAAAABJRU5ErkJggg==")
+        );
+
+        background-repeat: no-repeat;
+        background-position: 50%;
+        background-color: var(--internal-gutter-background-color);
+      }
+
       .gutter.gutter-horizontal {
+        background-image: var(--internal-gutter-handle);
         cursor: col-resize;
         float: left;
-        background-color: rgb(151, 152, 154);
+        border-left: var(--internal-gutter-border);
+        border-right: var(--internal-gutter-border);
       }
 
       .gutter.gutter-horizontal:hover {

--- a/src/item.ts
+++ b/src/item.ts
@@ -38,7 +38,6 @@ import fasSync from "@fortawesome/fontawesome-free/svgs/solid/sync-alt.svg";
 import faExpandAlt from "@fortawesome/fontawesome-free/svgs/solid/expand-alt.svg";
 import faCompressAlt from "@fortawesome/fontawesome-free/svgs/solid/compress-alt.svg";
 import fasCaretDown from "@fortawesome/fontawesome-free/svgs/solid/caret-down.svg";
-import faThList from "@fortawesome/fontawesome-free/svgs/solid/th-list.svg";
 
 import iconArrowClockwise from "~icons/arrow-clockwise.svg";
 import iconArrowLeft from "~icons/arrow-left.svg";

--- a/src/item.ts
+++ b/src/item.ts
@@ -1100,6 +1100,7 @@ class Item extends LitElement {
           <sl-button
             slot="footer"
             variant="primary"
+            size="small"
             @click="${this.onHideInfoDialog}"
             >Close</sl-button
           >

--- a/src/item.ts
+++ b/src/item.ts
@@ -1428,7 +1428,7 @@ class Item extends LitElement {
       ? dateTimeFormatter.format(tsToDate(this.ts) as Date)
       : "";
 
-    return html` <div class="is-right">
+    return html`
       <a
         href="#"
         role="button"
@@ -1559,7 +1559,7 @@ class Item extends LitElement {
           </sl-menu-item>
         </sl-menu>
       </sl-dropdown>
-    </div>`;
+    `;
   }
 
   private renderTimestamp() {

--- a/src/item.ts
+++ b/src/item.ts
@@ -112,6 +112,15 @@ export type TabData = EmbedReplayData & {
 };
 
 /**
+ * @cssPart replay-bar
+ * @cssPart replay-bar-container
+ * @cssPart replay-bar-input
+ * @cssProperty rwp-bar-background-color
+ * @cssProperty rwp-bar-text-color
+ * @cssProperty rwp-bar-button-color
+ * @cssProperty rwp-bar-input-background-color
+ * @cssProperty rwp-bar-input-border-color
+ * @cssProperty rwp-bar-input-text-color
  * @fires coll-loaded
  * @fires update-title
  * @fires about-show
@@ -642,12 +651,6 @@ class Item extends LitElement {
         vertical-align: text-top;
       }
 
-      .back fa-icon {
-        width: 1.5em;
-        vertical-align: bottom;
-        line-height: 0.5em;
-      }
-
       .tab {
         font-size: var(--sl-font-size-small);
       }
@@ -740,12 +743,57 @@ class Item extends LitElement {
         padding: 0.5em;
       }
 
+      .replay-bar-container {
+        --internal-bar-background-color: var(
+          --rwp-bar-background-color,
+          var(--sl-panel-background-color)
+        );
+        --internal-bar-text-color: var(
+          --rwp-bar-text-color,
+          var(--sl-color-neutral-700)
+        );
+        --internal-bar-button-color: var(
+          --rwp-bar-button-color,
+          var(--sl-color-neutral-500)
+        );
+        --internal-bar-input-background-color: var(
+          --rwp-bar-input-background-color,
+          var(--sl-panel-background-color)
+        );
+        --internal-bar-input-border-color: var(
+          --rwp-bar-input-border-color,
+          var(--sl-color-neutral-300)
+        );
+        --internal-bar-input-text-color: var(
+          --rwp-bar-input-text-color,
+          var(--sl-color-neutral-900)
+        );
+      }
+
       .replay-bar {
-        padding: 0.5em;
+        padding: var(--sl-spacing-x-small);
         max-width: none;
-        border-bottom: solid 0.1rem #97989a;
+        border-bottom: 1px solid var(--sl-panel-border-color);
         width: 100%;
-        background-color: white;
+        background-color: var(--internal-bar-background-color);
+        color: var(--internal-bar-text-color);
+      }
+
+      .replay-bar .field {
+        align-items: center;
+      }
+
+      .replay-bar .button {
+        background-color: transparent;
+        color: var(--internal-bar-button-color);
+      }
+
+      .replay-bar .input {
+        background-color: var(--internal-bar-input-background-color);
+        border-color: var(--internal-bar-input-border-color);
+        box-shadow: var(--sl-shadow-small);
+        color: var(--internal-bar-input-text-color);
+        font-size: var(--sl-font-size-small);
       }
 
       .replay-bar .icon {
@@ -753,7 +801,7 @@ class Item extends LitElement {
       }
 
       input#url {
-        border-radius: 4px;
+        border-radius: var(--sl-border-radius-medium);
       }
 
       .favicon img {
@@ -767,7 +815,7 @@ class Item extends LitElement {
         position: absolute;
         right: 0.5rem;
         z-index: 10;
-        background: #fff;
+        background: var(--internal-bar-input-background-color);
         top: 1px;
         bottom: 1px;
         display: flex;
@@ -809,8 +857,8 @@ class Item extends LitElement {
         background: linear-gradient(
           90deg,
           rgba(255, 255, 255, 0),
-          #fff 50%,
-          #fff
+          var(--internal-bar-input-background-color) 50%,
+          var(--internal-bar-input-background-color)
         );
         pointer-events: none;
       }
@@ -822,12 +870,9 @@ class Item extends LitElement {
         gap: var(--sl-spacing-x-small);
         align-items: center;
         transition: background-color var(--sl-transition-fast);
-        color: var(--sl-color-neutral-600);
+        background-color: var(--internal-bar-input-background-color);
         font-variant-numeric: tabular-nums;
-      }
-
-      .timestamp-dropdown-btn:hover {
-        color: var(--sl-color-neutral-900);
+        font-size: var(--sl-font-size-small);
       }
 
       .timestamp-dropdown-btn:hover .timestamp-count-badge {
@@ -1212,11 +1257,7 @@ class Item extends LitElement {
             aria-controls="contents"
           >
             <span class="icon is-small">
-              <wr-icon
-                class="has-text-grey"
-                aria-hidden="true"
-                .svg="${iconLayoutSidebar}"
-              ></wr-icon>
+              <wr-icon aria-hidden="true" .svg="${iconLayoutSidebar}"></wr-icon>
             </span>
           </a>`
         : ""}
@@ -1230,11 +1271,7 @@ class Item extends LitElement {
         aria-label="Back"
       >
         <span class="icon is-small">
-          <wr-icon
-            class="has-text-grey"
-            aria-hidden="true"
-            .svg="${iconArrowLeft}"
-          ></wr-icon>
+          <wr-icon aria-hidden="true" .svg="${iconArrowLeft}"></wr-icon>
         </span>
       </a>
       <a
@@ -1247,11 +1284,7 @@ class Item extends LitElement {
         aria-label="Forward"
       >
         <span class="icon is-small">
-          <wr-icon
-            class="has-text-grey"
-            aria-hidden="true"
-            .svg="${iconArrowRight}"
-          ></wr-icon>
+          <wr-icon aria-hidden="true" .svg="${iconArrowRight}"></wr-icon>
         </span>
       </a>
       <a
@@ -1270,7 +1303,6 @@ class Item extends LitElement {
           ${!this.isLoading
             ? html`
                 <wr-icon
-                  class="has-text-grey"
                   aria-hidden="true"
                   .svg="${iconArrowClockwise}"
                 ></wr-icon>
@@ -1295,37 +1327,42 @@ class Item extends LitElement {
         @click="${this.skipMenu}"
         >Skip replay navigation</a
       >
-      <nav class="replay-bar" aria-label="replay">
-        <div class="field has-addons">
-          ${this.renderToolbarLeft()}
-          <form @submit="${this.onSubmit}">
-            <div
-              class="control is-expanded ${showFavIcon ? "has-icons-left" : ""}"
-            >
-              <input
-                id="url"
-                class="input"
-                type="text"
-                @keydown="${this.onKeyDown}"
-                @blur="${this.onLostFocus}"
-                .value="${this.url}"
-                placeholder="Enter text to search or a URL to replay"
-              />
-              ${isReplay
-                ? this.clickToDownloadMode
-                  ? this.renderClickToDownloadNotify()
-                  : this.renderTimestamp()
-                : ""}
-              ${showFavIcon
-                ? html` <span class="favicon icon is-small is-left">
-                    <img src="${this.favIconUrl}" />
-                  </span>`
-                : html``}
-            </div>
-          </form>
-          ${this.renderToolbarRight()}
-        </div>
-      </nav>
+      <div class="replay-bar-container" part="replay-bar-container">
+        <nav class="replay-bar" aria-label="replay" part="replay-bar">
+          <div class="field has-addons">
+            ${this.renderToolbarLeft()}
+            <form @submit="${this.onSubmit}">
+              <div
+                class="control is-expanded ${showFavIcon
+                  ? "has-icons-left"
+                  : ""}"
+              >
+                <input
+                  part="replay-bar-input"
+                  id="url"
+                  class="input"
+                  type="text"
+                  @keydown="${this.onKeyDown}"
+                  @blur="${this.onLostFocus}"
+                  .value="${this.url}"
+                  placeholder="Enter text to search or a URL to replay"
+                />
+                ${isReplay
+                  ? this.clickToDownloadMode
+                    ? this.renderClickToDownloadNotify()
+                    : this.renderTimestamp()
+                  : ""}
+                ${showFavIcon
+                  ? html` <span class="favicon icon is-small is-left">
+                      <img src="${this.favIconUrl}" />
+                    </span>`
+                  : html``}
+              </div>
+            </form>
+            ${this.renderToolbarRight()}
+          </div>
+        </nav>
+      </div>
       <p id="skip-replay-target" tabindex="-1" class="is-sr-only">Skipped</p>`;
   }
 
@@ -1334,7 +1371,7 @@ class Item extends LitElement {
       id="click-download-msg"
       class="loc-overlay has-background-link-light is-size-7"
     >
-      <div class="ml-4 is-flex">
+      <div class="ml-x is-flex">
         Select image or media highlighted with 🟦 (blue box) on hover to
         download.
       </div>
@@ -1369,7 +1406,6 @@ class Item extends LitElement {
       >
         <span class="icon is-small">
           <wr-icon
-            class="has-text-grey"
             aria-hidden="true"
             .svg="${this.isFullscreen
               ? iconExitFullscreen
@@ -1388,7 +1424,6 @@ class Item extends LitElement {
         >
           <span class="icon is-small">
             <wr-icon
-              class="has-text-grey"
               aria-hidden="true"
               .svg="${iconThreeDotsVertical}"
             ></wr-icon>
@@ -1406,7 +1441,6 @@ class Item extends LitElement {
           >
             <span class="icon is-small">
               <wr-icon
-                class="has-text-grey"
                 aria-hidden="true"
                 .svg="${this.isFullscreen
                   ? iconExitFullscreen
@@ -1427,7 +1461,6 @@ class Item extends LitElement {
               >
                 <span class="icon is-small">
                   <wr-icon
-                    class="has-text-grey"
                     aria-hidden="true"
                     .svg="${iconLayoutSidebar}"
                   ></wr-icon>
@@ -1447,7 +1480,6 @@ class Item extends LitElement {
                   <span class="icon is-small">
                     <fa-icon
                       size="1.0em"
-                      class="has-text-grey"
                       aria-hidden="true"
                       .svg="${fasSync}"
                     ></fa-icon>
@@ -1466,7 +1498,6 @@ class Item extends LitElement {
                   <span class="icon is-small">
                     <fa-icon
                       size="1.0em"
-                      class="has-text-grey"
                       aria-hidden="true"
                       .svg="${fasFileDownload}"
                     ></fa-icon>
@@ -1486,7 +1517,6 @@ class Item extends LitElement {
                   <span class="icon is-small">
                     <fa-icon
                       size="1.0em"
-                      class="has-text-grey"
                       aria-hidden="true"
                       .svg="${fasDownload}"
                     ></fa-icon>
@@ -1509,11 +1539,7 @@ class Item extends LitElement {
                 @click="${this.onShowInfoDialog}"
               >
                 <span class="icon is-small">
-                  <fa-icon
-                    class="has-text-grey"
-                    aria-hidden="true"
-                    .svg="${fasInfoIcon}"
-                  ></fa-icon>
+                  <fa-icon aria-hidden="true" .svg="${fasInfoIcon}"></fa-icon>
                 </span>
                 <span>Archive Info</span>
               </a>`
@@ -1525,12 +1551,7 @@ class Item extends LitElement {
             class="dropdown-item"
             @click="${this.onAbout}"
           >
-            <fa-icon
-              class="has-text-grey"
-              size="1.0rem"
-              aria-hidden="true"
-              .svg=${rwpIcon}
-            ></fa-icon>
+            <fa-icon size="1.0rem" aria-hidden="true" .svg=${rwpIcon}></fa-icon>
             <span>&nbsp;About ${this.appName}</span>
             <span class="menu-version">(${this.appVersion})</span>
           </a>

--- a/src/item.ts
+++ b/src/item.ts
@@ -1,5 +1,5 @@
-import { LitElement, html, css, type PropertyValues } from "lit";
-import { property } from "lit/decorators.js";
+import { LitElement, html, css, type PropertyValues, nothing } from "lit";
+import { property, state } from "lit/decorators.js";
 import { ref, createRef, type Ref } from "lit/directives/ref.js";
 import type {
   SlDialog,
@@ -35,9 +35,10 @@ import farPages from "@fortawesome/fontawesome-free/svgs/regular/file-image.svg"
 import fasInfoIcon from "@fortawesome/fontawesome-free/svgs/solid/info-circle.svg";
 import fasSync from "@fortawesome/fontawesome-free/svgs/solid/sync-alt.svg";
 
-import fasAngleLeft from "@fortawesome/fontawesome-free/svgs/solid/angle-left.svg";
-import fasAngleRight from "@fortawesome/fontawesome-free/svgs/solid/angle-right.svg";
+import faExpandAlt from "@fortawesome/fontawesome-free/svgs/solid/expand-alt.svg";
+import faCompressAlt from "@fortawesome/fontawesome-free/svgs/solid/compress-alt.svg";
 import fasCaretDown from "@fortawesome/fontawesome-free/svgs/solid/caret-down.svg";
+import faThList from "@fortawesome/fontawesome-free/svgs/solid/th-list.svg";
 
 import iconArrowClockwise from "~icons/arrow-clockwise.svg";
 import iconArrowLeft from "~icons/arrow-left.svg";
@@ -219,6 +220,9 @@ class Item extends LitElement {
 
   @property({ type: Boolean })
   clickToDownloadMode = false;
+
+  @state()
+  private tabDataBeforeFullView?: TabData;
 
   private splitter: Split.Instance | null = null;
 
@@ -1148,25 +1152,6 @@ class Item extends LitElement {
       aria-label="tabs"
     >
       <ul>
-        ${isSidebar
-          ? html` <li class="sidebar-nav left">
-              <a
-                role="button"
-                href="#"
-                @click="${this.onHideSidebar}"
-                @keyup="${clickOnSpacebarPress}"
-                class="is-marginless is-size-6 is-paddingless"
-              >
-                <fa-icon
-                  title="Hide"
-                  .svg="${fasAngleLeft}"
-                  aria-hidden="true"
-                ></fa-icon>
-                <span class="nav-hover" aria-hidden="true">Hide</span>
-                <span class="is-sr-only">Hide Sidebar</span>
-              </a>
-            </li>`
-          : ""}
         ${this.hasStory
           ? html` <li
               class="${this.tabData.view === EmbedReplayDataView.Story
@@ -1253,7 +1238,7 @@ class Item extends LitElement {
         </li>
 
         ${isSidebar
-          ? html` <li class="sidebar-nav right">
+          ? html`<li class="sidebar-nav right">
               <a
                 role="button"
                 href="#"
@@ -1261,16 +1246,32 @@ class Item extends LitElement {
                 @keyup="${clickOnSpacebarPress}"
                 class="is-marginless is-size-6 is-paddingless"
               >
-                <span class="nav-hover" aria-hidden="true">Expand</span>
                 <span class="is-sr-only">Expand Sidebar to Full View</span>
                 <fa-icon
                   title="Expand"
-                  .svg="${fasAngleRight}"
+                  .svg="${faExpandAlt}"
                   aria-hidden="true"
                 ></fa-icon>
               </a>
             </li>`
-          : ""}
+          : this.tabDataBeforeFullView
+          ? html` <li class="sidebar-nav right">
+              <a
+                role="button"
+                href="#"
+                @click="${this.onSplitView}"
+                @keyup="${clickOnSpacebarPress}"
+                class="is-marginless is-size-6 is-paddingless"
+              >
+                <span class="is-sr-only">Go Back to Split View</span>
+                <fa-icon
+                  title="Contract"
+                  .svg="${faCompressAlt}"
+                  aria-hidden="true"
+                ></fa-icon>
+              </a>
+            </li>`
+          : nothing}
       </ul>
     </nav>`;
   }
@@ -1288,8 +1289,8 @@ class Item extends LitElement {
             @click="${this.onShowPages}"
             @keyup="${clickOnSpacebarPress}"
             ?disabled="${!isReplay}"
-            title="Browse Contents"
-            aria-label="Browse Contents"
+            title="Toggle Browse Contents"
+            aria-label="Toggle Browse Contents"
             aria-controls="contents"
           >
             <span class="icon is-small">
@@ -1865,14 +1866,23 @@ class Item extends LitElement {
     }
   }
 
-  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
-  onFullPageView(event) {
+  onFullPageView(event: MouseEvent) {
     event.preventDefault();
+
+    this.tabDataBeforeFullView = this.tabData;
     this.updateTabData({ url: "", ts: "" });
   }
 
-  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
-  onHideSidebar(event) {
+  onSplitView(event: MouseEvent) {
+    event.preventDefault();
+
+    if (this.tabDataBeforeFullView) {
+      this.updateTabData(this.tabDataBeforeFullView);
+      this.tabDataBeforeFullView = undefined;
+    }
+  }
+
+  onHideSidebar(event: MouseEvent) {
     event.preventDefault();
     this.showSidebar = false;
   }

--- a/src/item.ts
+++ b/src/item.ts
@@ -27,22 +27,20 @@ import {
 import fasTriangleExclamation from "@fortawesome/fontawesome-free/svgs/solid/exclamation-triangle.svg";
 import fasBook from "@fortawesome/fontawesome-free/svgs/solid/book.svg";
 
-import fasDownload from "@fortawesome/fontawesome-free/svgs/solid/download.svg";
-import fasFileDownload from "@fortawesome/fontawesome-free/svgs/regular/arrow-alt-circle-down.svg";
-
 import farResources from "@fortawesome/fontawesome-free/svgs/solid/puzzle-piece.svg";
 import farPages from "@fortawesome/fontawesome-free/svgs/regular/file-image.svg";
-import fasInfoIcon from "@fortawesome/fontawesome-free/svgs/solid/info-circle.svg";
-import fasSync from "@fortawesome/fontawesome-free/svgs/solid/sync-alt.svg";
 
 import fasCaretDown from "@fortawesome/fontawesome-free/svgs/solid/caret-down.svg";
 
 import iconArrowClockwise from "~icons/arrow-clockwise.svg";
 import iconArrowLeft from "~icons/arrow-left.svg";
 import iconArrowRight from "~icons/arrow-right.svg";
+import iconArrowRepeat from "~icons/arrow-repeat.svg";
 import iconArrowsExpandVertical from "~icons/arrows-expand-vertical.svg";
 import iconArrowBarLeft from "~icons/arrow-bar-left.svg";
 import iconArrowsFullscreen from "~icons/arrows-fullscreen.svg";
+import iconInfoSquare from "~icons/info-square.svg";
+import iconDownload from "~icons/download.svg";
 import iconExitFullscreen from "~icons/fullscreen-exit.svg";
 import iconLayoutSidebar from "~icons/layout-sidebar.svg";
 import iconThreeDotsVertical from "~icons/three-dots-vertical.svg";
@@ -125,6 +123,7 @@ export type TabData = EmbedReplayData & {
  * @cssProperty rwp-bar-input-background-color
  * @cssProperty rwp-bar-input-border-color
  * @cssProperty rwp-bar-input-text-color
+ * @cssProperty rwp-bar-active-text-color
  * @fires coll-loaded
  * @fires update-title
  * @fires about-show
@@ -174,9 +173,6 @@ class Item extends LitElement {
 
   @property({ type: Boolean })
   isFullscreen: boolean | null = null;
-
-  @property({ type: Boolean })
-  menuActive = false;
 
   @property({ type: String })
   embed: string | null = null;
@@ -781,6 +777,10 @@ class Item extends LitElement {
           --rwp-bar-input-text-color,
           var(--sl-color-neutral-900)
         );
+        --internal-bar-active-text-color: var(
+          --rwp-bar-active-text-color,
+          var(--sl-color-blue-500)
+        );
       }
 
       .replay-bar {
@@ -794,6 +794,10 @@ class Item extends LitElement {
 
       .replay-bar .field {
         align-items: center;
+      }
+
+      .replay-bar .icon {
+        font-size: 1.125rem;
       }
 
       .replay-bar .button {
@@ -814,8 +818,8 @@ class Item extends LitElement {
         font-size: var(--sl-font-size-small);
       }
 
-      .replay-bar .icon {
-        font-size: 1.125rem;
+      .replay-bar-overflow-actions sl-menu-item::part(label) {
+        font-size: var(--sl-font-size-small);
       }
 
       .favicon img {
@@ -919,18 +923,15 @@ class Item extends LitElement {
       }
 
       .menu-head {
-        font-size: 10px;
-        font-weight: bold;
+        font-size: var(--sl-font-size-2x-small);
+        font-weight: var(--sl-font-weight-bold);
         display: block;
       }
       .menu-logo {
         vertical-align: middle;
       }
       .menu-version {
-        font-size: 10px;
-      }
-      .dropdown-item.info {
-        font-style: italic;
+        font-size: var(--sl-font-size-x-small);
       }
 
       input:focus + #datetime {
@@ -1021,7 +1022,7 @@ class Item extends LitElement {
       .sidebar-nav:hover span.nav-hover,
       .sidebar-nav:focus-within span.nav-hover {
         display: initial;
-        color: rgb(72, 118, 255);
+        color: var(--internal-bar-active-text-color);
       }
 
       .sidebar-nav.left {
@@ -1032,6 +1033,10 @@ class Item extends LitElement {
         right: 8px;
       }
 
+      .sidebar-nav-toggle[aria-selected="true"] {
+        color: var(--internal-bar-active-text-color);
+      }
+
       /* Since the replay sometimes programmatically receives keyboard focus,
        and that is visually unexpected for mouse-users, and since this won't
        particularly trip up keyboard users, just remove the focus style. */
@@ -1040,7 +1045,7 @@ class Item extends LitElement {
       }
       /* Some keyboard-users may see this replacement style */
       wr-coll-replay:focus-visible {
-        outline: 1px solid rgb(72, 118, 255);
+        outline: 1px solid var(--internal-bar-active-text-color);
       }
     `;
   }
@@ -1278,7 +1283,7 @@ class Item extends LitElement {
         ? html` <a
             href="#"
             role="button"
-            class="button narrow is-borderless is-hidden-mobile ${!isReplay
+            class="sidebar-nav-toggle button narrow is-borderless is-hidden-mobile ${!isReplay
               ? "grey-disabled"
               : ""}"
             @click="${this.onShowPages}"
@@ -1287,6 +1292,7 @@ class Item extends LitElement {
             title="Toggle Browse Contents"
             aria-label="Toggle Browse Contents"
             aria-controls="contents"
+            aria-selected=${this.showSidebar === true}
           >
             <span class="icon is-small">
               <wr-icon aria-hidden="true" .svg="${iconLayoutSidebar}"></wr-icon>
@@ -1422,10 +1428,7 @@ class Item extends LitElement {
       ? dateTimeFormatter.format(tsToDate(this.ts) as Date)
       : "";
 
-    return html` <div
-      class="dropdown is-right ${this.menuActive ? "is-active" : ""}"
-      @click="${() => (this.menuActive = false)}"
-    >
+    return html` <div class="is-right">
       <a
         href="#"
         role="button"
@@ -1445,13 +1448,10 @@ class Item extends LitElement {
           ></wr-icon>
         </span>
       </a>
-      <div class="dropdown-trigger">
+      <sl-dropdown class="replay-bar-overflow-actions">
         <button
+          slot="trigger"
           class="button is-borderless"
-          aria-haspopup="true"
-          aria-controls="menu-dropdown"
-          aria-expanded="${this.menuActive}"
-          @click="${this.onMenu}"
           aria-label="more replay controls"
         >
           <span class="icon is-small">
@@ -1461,134 +1461,104 @@ class Item extends LitElement {
             ></wr-icon>
           </span>
         </button>
-      </div>
-      <div class="dropdown-menu" id="menu-dropdown">
-        <div class="dropdown-content">
-          <a
-            href="#"
-            role="button"
-            class="dropdown-item is-hidden-desktop"
+
+        <sl-menu>
+          <sl-menu-item
+            class="is-hidden-desktop"
             @click="${this.onFullscreenToggle}"
-            @keyup="${clickOnSpacebarPress}"
           >
-            <span class="icon is-small">
-              <wr-icon
-                aria-hidden="true"
-                .svg="${this.isFullscreen
-                  ? iconExitFullscreen
-                  : iconArrowsFullscreen}"
-              ></wr-icon>
-            </span>
-            <span>Full Screen</span>
-          </a>
+            <wr-icon
+              slot="prefix"
+              aria-hidden="true"
+              .svg=${this.isFullscreen
+                ? iconExitFullscreen
+                : iconArrowsFullscreen}
+            ></wr-icon>
+            Full Screen
+          </sl-menu-item>
           ${this.browsable
-            ? html` <a
-                href="#"
-                role="button"
-                class="dropdown-item is-hidden-tablet ${!isReplay
-                  ? "grey-disabled"
-                  : ""}"
+            ? html`<sl-menu-item
+                class="is-hidden-tablet"
+                ?disabled=${!isReplay}
                 @click="${this.onShowPages}"
-                @keyup="${clickOnSpacebarPress}"
               >
-                <span class="icon is-small">
-                  <wr-icon
-                    aria-hidden="true"
-                    .svg="${iconLayoutSidebar}"
-                  ></wr-icon>
-                </span>
-                <span>Browse Contents</span>
-              </a>`
-            : ""}
+                <wr-icon
+                  slot="prefix"
+                  aria-hidden="true"
+                  .svg=${iconLayoutSidebar}
+                ></wr-icon>
+                Browse Contents
+              </sl-menu-item>`
+            : nothing}
           ${this.clearable
-            ? html` <hr class="dropdown-divider is-hidden-desktop" />
-                <a
-                  href="#"
-                  role="button"
-                  class="dropdown-item"
-                  @click="${this.onPurgeCache}"
-                  @keyup="${clickOnSpacebarPress}"
-                >
-                  <span class="icon is-small">
-                    <fa-icon
-                      size="1.0em"
-                      aria-hidden="true"
-                      .svg="${fasSync}"
-                    ></fa-icon>
-                  </span>
-                  <span>Purge Cache + Full Reload</span>
-                </a>`
-            : html``}
+            ? html` <sl-divider class="is-hidden-desktop"></sl-divider>
+                <sl-menu-item @click="${this.onPurgeCache}">
+                  <wr-icon
+                    slot="prefix"
+                    aria-hidden="true"
+                    .svg=${iconArrowRepeat}
+                  ></wr-icon>
+                  Purge Cache + Full Reload
+                </sl-menu-item>`
+            : nothing}
           ${isReplay && !this.embedOpts.noMediaDownloadUI
-            ? html`<hr class="dropdown-divider" />
-                <a
-                  @click="${this.clickToDownload}"
-                  role="button"
-                  class="dropdown-item"
-                  @keyup="${clickOnSpacebarPress}"
-                >
-                  <span class="icon is-small">
-                    <fa-icon
-                      size="1.0em"
-                      aria-hidden="true"
-                      .svg="${fasFileDownload}"
-                    ></fa-icon>
-                  </span>
-                  <span>Select Media to Download</span>
-                </a>`
-            : html``}
+            ? html`<sl-menu-item @click="${this.clickToDownload}">
+                <wr-icon
+                  slot="prefix"
+                  aria-hidden="true"
+                  .svg=${iconDownload}
+                ></wr-icon>
+                Select Media to Download
+              </sl-menu-item>`
+            : nothing}
           ${(!this.editable && this.downloadUrl?.startsWith("http://")) ||
           this.downloadUrl?.startsWith("https://")
-            ? html` <hr class="dropdown-divider" />
-                <a
-                  href="${this.downloadUrl}"
-                  role="button"
-                  class="dropdown-item"
-                  @keyup="${clickOnSpacebarPress}"
-                >
-                  <span class="icon is-small">
-                    <fa-icon
-                      size="1.0em"
-                      aria-hidden="true"
-                      .svg="${fasDownload}"
-                    ></fa-icon>
-                  </span>
-                  <span>Download Archive</span>
-                </a>`
-            : html``}
+            ? html`<sl-menu-item
+                @click="${(e: MouseEvent) =>
+                  (e.target as LitElement).querySelector("a")?.click()}"
+              >
+                <wr-icon
+                  slot="prefix"
+                  aria-hidden="true"
+                  .svg=${iconDownload}
+                ></wr-icon>
+                Download Archive
+                <a href=${this.downloadUrl} aria-hidden="true"></a>
+              </sl-menu-item>`
+            : nothing}
           ${dateStr
-            ? html` <hr class="dropdown-divider is-hidden-desktop" />
-                <div class="dropdown-item info is-hidden-tablet">
-                  <span class="menu-head">Capture Date</span>${dateStr}
-                </div>`
-            : ""}
+            ? html`<sl-divider class="is-hidden-tablet"></sl-divider>
+                <sl-menu-label class="is-hidden-tablet">
+                  <div>
+                    <span class="menu-head">Capture Date</span>
+                    ${dateStr}
+                  </div>
+                </sl-menu-label>`
+            : nothing}
           ${!this.editable &&
           (this.downloadUrl === this.sourceUrl || !this.embed)
-            ? html` <a
-                href="#"
-                role="button"
-                class="dropdown-item"
-                @click="${this.onShowInfoDialog}"
-              >
-                <span class="icon is-small">
-                  <fa-icon aria-hidden="true" .svg="${fasInfoIcon}"></fa-icon>
-                </span>
-                <span>Archive Info</span>
-              </a>`
-            : ``}
-          <hr class="dropdown-divider" />
-          <a
-            href="#"
-            role="button"
-            class="dropdown-item"
-            @click="${this.onAbout}"
-          >
-            <fa-icon size="1.0rem" aria-hidden="true" .svg=${rwpIcon}></fa-icon>
-            <span>&nbsp;About ${this.appName}</span>
-            <span class="menu-version">(${this.appVersion})</span>
-          </a>
-        </div>
-      </div>
+            ? html`<sl-menu-item @click="${this.onShowInfoDialog}">
+                <wr-icon
+                  slot="prefix"
+                  aria-hidden="true"
+                  .svg=${iconInfoSquare}
+                ></wr-icon>
+                Archive Info
+              </sl-menu-item>`
+            : nothing}
+          <sl-divider></sl-divider>
+          <sl-menu-item @click="${this.onAbout}">
+            <fa-icon
+              slot="prefix"
+              size="1.0rem"
+              aria-hidden="true"
+              .svg=${rwpIcon}
+            ></fa-icon>
+            About ${this.appName}
+            <span slot="suffix" class="menu-version">${this.appVersion}</span>
+          </sl-menu-item>
+        </sl-menu>
+      </sl-dropdown>
     </div>`;
   }
 
@@ -1801,25 +1771,9 @@ class Item extends LitElement {
   }
 
   // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
-  onMenu(event) {
-    event.stopPropagation();
-    this.menuActive = !this.menuActive;
-
-    if (this.menuActive) {
-      document.addEventListener(
-        "click",
-        () => {
-          this.menuActive = false;
-        },
-        { once: true },
-      );
-    }
-  }
-
-  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onFullscreenToggle(event) {
     event.preventDefault();
-    this.menuActive = false;
+
     if (!this.isFullscreen) {
       // TODO: Fix this the next time the file is edited.
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -1831,22 +1785,19 @@ class Item extends LitElement {
     }
   }
 
-  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
-  onGoBack(event) {
+  onGoBack(event: Event) {
     event.preventDefault();
-    this.menuActive = false;
+
     window.history.back();
   }
 
-  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
-  onGoForward(event) {
+  onGoForward(event: Event) {
     event.preventDefault();
-    this.menuActive = false;
+
     window.history.forward();
   }
 
-  // @ts-expect-error [// TODO: Fix this the next time the file is edited.] - TS7006 - Parameter 'event' implicitly has an 'any' type.
-  onShowPages(event) {
+  onShowPages(event: Event) {
     event.preventDefault();
     // show sidebar for tablet or wider, or hide sidebar
     if (this.showSidebar || document.documentElement.clientWidth >= 769) {
@@ -2073,8 +2024,6 @@ class Item extends LitElement {
     if (event) {
       event.preventDefault();
     }
-
-    this.menuActive = false;
 
     if (this.tabData.url) {
       const replay = this.renderRoot.querySelector<Replay>("wr-coll-replay");

--- a/src/item.ts
+++ b/src/item.ts
@@ -822,16 +822,20 @@ class Item extends LitElement {
         font-size: var(--sl-font-size-small);
       }
 
+      .favicon.icon {
+        margin-top: var(--sl-spacing-x-small);
+        margin-left: var(--sl-spacing-x-small);
+        width: 1.25rem !important;
+        height: 1.25rem !important;
+      }
+
       .favicon img {
-        width: 20px;
-        height: 20px;
-        margin: 8px;
-        /*filter: drop-shadow(1px 1px 2px grey);*/
+        object-fit: contain;
       }
 
       #datetime {
         position: absolute;
-        right: var(--sl-spacing-small);
+        right: var(--sl-spacing-x-small);
         z-index: 10;
         background: var(--internal-bar-input-background-color);
         top: 1px;

--- a/src/item.ts
+++ b/src/item.ts
@@ -651,6 +651,10 @@ class Item extends LitElement {
         min-width: 0px;
       }
 
+      .input {
+        transition: all var(--sl-transition-fast);
+      }
+
       .icon {
         vertical-align: text-top;
       }
@@ -794,20 +798,17 @@ class Item extends LitElement {
         color: var(--internal-bar-button-color);
       }
 
-      .replay-bar .input {
+      .replay-bar-form {
+        margin: 0 var(--sl-spacing-small);
+      }
+
+      .replay-bar-input {
         background-color: var(--internal-bar-input-background-color);
         border-color: var(--internal-bar-input-border-color);
+        border-radius: var(--sl-border-radius-medium);
         box-shadow: var(--sl-shadow-small);
         color: var(--internal-bar-input-text-color);
         font-size: var(--sl-font-size-small);
-      }
-
-      .replay-bar .icon {
-        font-size: 1.125rem;
-      }
-
-      input#url {
-        border-radius: var(--sl-border-radius-medium);
       }
 
       .favicon img {
@@ -819,7 +820,7 @@ class Item extends LitElement {
 
       #datetime {
         position: absolute;
-        right: 0.5rem;
+        right: var(--sl-spacing-small);
         z-index: 10;
         background: var(--internal-bar-input-background-color);
         top: 1px;
@@ -827,6 +828,7 @@ class Item extends LitElement {
         display: flex;
         align-items: center;
         line-height: 2;
+        font-size: var(--sl-font-size-small);
       }
 
       #click-download-msg {
@@ -1344,7 +1346,7 @@ class Item extends LitElement {
         <nav class="replay-bar" aria-label="replay" part="replay-bar">
           <div class="field has-addons">
             ${this.renderToolbarLeft()}
-            <form @submit="${this.onSubmit}">
+            <form class="replay-bar-form" @submit="${this.onSubmit}">
               <div
                 class="control is-expanded ${showFavIcon
                   ? "has-icons-left"
@@ -1353,7 +1355,7 @@ class Item extends LitElement {
                 <input
                   part="replay-bar-input"
                   id="url"
-                  class="input"
+                  class="input replay-bar-input"
                   type="text"
                   @keydown="${this.onKeyDown}"
                   @blur="${this.onLostFocus}"

--- a/src/pageentry.ts
+++ b/src/pageentry.ts
@@ -1,6 +1,13 @@
 import prettyBytes from "pretty-bytes";
 
-import { LitElement, html, css, unsafeCSS, type PropertyValues } from "lit";
+import {
+  LitElement,
+  html,
+  css,
+  unsafeCSS,
+  type PropertyValues,
+  nothing,
+} from "lit";
 import { property, state } from "lit/decorators.js";
 
 import "keyword-mark-element/lib/keyword-mark.js";
@@ -50,6 +57,9 @@ class PageEntry extends LitElement {
 
   @property({ type: Boolean })
   isSidebar = false;
+
+  @property({ type: Boolean })
+  useFaviconFallback = false;
 
   @state()
   thumbnailValid = true;
@@ -124,7 +134,8 @@ class PageEntry extends LitElement {
         flex-direction: column;
         align-items: center;
         justify-content: center;
-        overflow: clip;
+        overflow: hidden;
+        padding: var(--sl-spacing-2x-small);
       }
 
       .thumbnail-placeholder-content .icon {
@@ -133,7 +144,7 @@ class PageEntry extends LitElement {
       }
 
       .thumbnail-placeholder-label {
-        font-size: var(--sl-font-size-x-small);
+        font-size: var(--sl-font-size-2x-small);
         color: var(--sl-color-neutral-500);
         line-height: 1;
       }
@@ -152,23 +163,16 @@ class PageEntry extends LitElement {
         transition: color var(--sl-transition-x-fast);
       }
 
-      .favicon {
-        display: inline-block;
-        vertical-align: -0.25rem;
-      }
-
       .media-left .favicon {
-        width: 2rem;
-        height: 2rem;
-      }
-      .media-left img.favicon {
-        filter: drop-shadow(1px 1px 2px grey);
+        object-fit: contain;
       }
 
       .media-content .favicon {
         width: 1.15rem;
         height: 1.15rem;
         margin: 0 0.25rem;
+        display: inline-block;
+        vertical-align: -0.25rem;
       }
 
       .media-left {
@@ -304,7 +308,7 @@ class PageEntry extends LitElement {
                   )}"
                 >
                   <p class="page-title text">
-                    ${this.renderFavicon()}
+                    ${this.thumbnailValid ? this.renderFavicon() : nothing}
                     <keyword-mark keywords="${this.query}"
                       >${p.title || p.url}</keyword-mark
                     >
@@ -359,21 +363,30 @@ class PageEntry extends LitElement {
 
   private renderPageIcon() {
     if (!this.thumbnailValid) {
-      return html`<div class="thumbnail thumbnail-placeholder image is-16by9">
+      return html`<div
+        class="thumbnail-placeholder image is-16by9 ${this.useFaviconFallback
+          ? "favicon-fallback"
+          : "thumbnail"}"
+      >
         <div class="thumbnail-placeholder-content">
-          <span class="icon is-small">
-            <fa-icon .svg="${faFileImage}" aria-hidden="true"></fa-icon>
-          </span>
-          <span class="thumbnail-placeholder-label">No image</span>
+          ${this.useFaviconFallback
+            ? this.renderFavicon()
+            : html`<span class="icon is-small">
+                  <fa-icon .svg="${faFileImage}" aria-hidden="true"></fa-icon>
+                </span>
+                <span class="thumbnail-placeholder-label">No image</span>`}
         </div>
       </div>`;
     }
-    return html`<img
-      class="thumbnail"
-      @error=${() => (this.thumbnailValid = false)}
-      src=${`${this.getReplayPrefix()}/urn:thumbnail:${this.page!.url}`}
-      loading="lazy"
-    />`;
+
+    return html`<div class="image is-16by9">
+      <img
+        class="thumbnail"
+        @error=${() => (this.thumbnailValid = false)}
+        src=${`${this.getReplayPrefix()}/urn:thumbnail:${this.page!.url}`}
+        loading="lazy"
+      />
+    </div>`;
   }
 
   private renderFavicon() {

--- a/src/pageentry.ts
+++ b/src/pageentry.ts
@@ -12,7 +12,7 @@ import { property, state } from "lit/decorators.js";
 
 import "keyword-mark-element/lib/keyword-mark.js";
 
-import faFileImage from "@fortawesome/fontawesome-free/svgs/solid/file-image.svg";
+import iconImageAlt from "~icons/image-alt.svg";
 
 import { getPageDateTS, getReplayLink } from "./pageutils";
 
@@ -372,7 +372,7 @@ class PageEntry extends LitElement {
           ${this.useFaviconFallback
             ? this.renderFavicon()
             : html`<span class="icon is-small">
-                  <fa-icon .svg="${faFileImage}" aria-hidden="true"></fa-icon>
+                  <wr-icon .svg="${iconImageAlt}" aria-hidden="true"></wr-icon>
                 </span>
                 <span class="thumbnail-placeholder-label">No image</span>`}
         </div>

--- a/src/pageentry.ts
+++ b/src/pageentry.ts
@@ -17,6 +17,7 @@ import {
   timeFormatter,
 } from "./utils/dateTimeFormatter";
 import type { TabNavEvent } from "./events";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 // ===========================================================================
 class PageEntry extends LitElement {
@@ -72,6 +73,18 @@ class PageEntry extends LitElement {
         width: unset !important;
       }
 
+      :host(.sidebar) .page-title {
+        font-size: var(--sl-font-size-small);
+      }
+
+      :host(.sidebar) .page-link:not(.current):hover {
+        background-color: var(--sl-color-neutral-50);
+      }
+
+      :host(.sidebar) .current {
+        background-color: var(--sl-color-blue-100);
+      }
+
       :host(.sidebar) {
         width: 100%;
       }
@@ -125,9 +138,23 @@ class PageEntry extends LitElement {
         line-height: 1;
       }
 
+      .page-link {
+        transition: background-color var(--sl-transition-x-fast);
+      }
+
+      .page-link:hover .page-title {
+        color: var(--sl-color-blue-700);
+      }
+
+      .page-title {
+        font-weight: var(--sl-font-weight-bold);
+        color: var(--sl-color-blue-600);
+        transition: color var(--sl-transition-x-fast);
+      }
+
       .favicon {
         display: inline-block;
-        vertical-align: text-bottom;
+        vertical-align: -0.25rem;
       }
 
       .media-left .favicon {
@@ -174,16 +201,6 @@ class PageEntry extends LitElement {
 
       ${PageEntry.sidebarStyles(unsafeCSS`:host(.sidebar)`)}
 
-      .current a {
-        background-color: rgb(207, 243, 255);
-        display: block;
-      }
-
-      .current .curr-page {
-        font-size: 9px;
-        color: black;
-      }
-
       .is-inline-date {
         display: none;
       }
@@ -196,11 +213,13 @@ class PageEntry extends LitElement {
         font-variant-numeric: tabular-nums;
       }
 
-      .date-time {
+      .date-time,
+      .is-inline-date {
         font-size: var(--sl-font-size-small);
+        color: var(--sl-color-neutral-700);
       }
 
-      .url {
+      .page-url {
         font-size: var(--sl-font-size-small);
       }
     `);
@@ -224,10 +243,6 @@ class PageEntry extends LitElement {
       }
       ${prefix} .is-inline-date {
         display: initial !important;
-        font-size: var(--sl-font-size-small);
-      }
-      ${prefix} .media-left {
-        padding-left: 0.75rem;
       }
     `;
   }
@@ -270,10 +285,13 @@ class PageEntry extends LitElement {
           <div>${date ? dateFormatter.format(date) : ""}</div>
           <div class="date-time">${date ? timeFormatter.format(date) : ""}</div>
         </div>
-        <div class="column">
+        <div
+          class="page-link column ${this.isCurrent ? "current" : ""}"
+          aria-current=${ifDefined(this.isCurrent ? "location" : undefined)}
+        >
           <div class="media">
             <figure class="media-left">${this.renderPageIcon()}</figure>
-            <div class="media-content ${this.isCurrent ? "current" : ""}">
+            <div class="media-content">
               <div role="heading" aria-level="${this.isSidebar ? "4" : "3"}">
                 <a
                   @dblclick="${this.onReload}"
@@ -285,18 +303,18 @@ class PageEntry extends LitElement {
                     this.page!.waczhash,
                   )}"
                 >
-                  <p class="is-size-6 has-text-weight-bold has-text-link text">
+                  <p class="page-title text">
                     ${this.renderFavicon()}
                     <keyword-mark keywords="${this.query}"
                       >${p.title || p.url}</keyword-mark
                     >
                   </p>
-                  <p class="url has-text-dark text">
+                  <p class="page-url has-text-dark text">
                     <keyword-mark keywords="${this.query}"
                       >${p.url}</keyword-mark
                     >
                   </p>
-                  <p class="has-text-grey-dark text is-inline-date">
+                  <p class="text is-inline-date">
                     ${date ? dateTimeFormatter.format(date) : ""}
                   </p>
                 </a>

--- a/src/pageentry.ts
+++ b/src/pageentry.ts
@@ -87,6 +87,14 @@ class PageEntry extends LitElement {
         font-size: var(--sl-font-size-small);
       }
 
+      :host(.sidebar) .page-title,
+      :host(.sidebar) .page-url {
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 2;
+        overflow: hidden;
+      }
+
       :host(.sidebar) .page-link:not(.current):hover {
         background-color: var(--sl-color-neutral-50);
       }
@@ -309,12 +317,14 @@ class PageEntry extends LitElement {
                 >
                   <p class="page-title text">
                     ${this.thumbnailValid ? this.renderFavicon() : nothing}
-                    <keyword-mark keywords="${this.query}"
+                    <keyword-mark
+                      keywords="${this.query}"
+                      title="${p.title || p.url}"
                       >${p.title || p.url}</keyword-mark
                     >
                   </p>
                   <p class="page-url has-text-dark text">
-                    <keyword-mark keywords="${this.query}"
+                    <keyword-mark keywords="${this.query}" title="${p.url}"
                       >${p.url}</keyword-mark
                     >
                   </p>
@@ -331,9 +341,7 @@ class PageEntry extends LitElement {
                   : html``}
               </div>
               ${hasSize
-                ? html` <div class="media-right" style="margin-right: 2em">
-                    ${prettyBytes(p.size)}
-                  </div>`
+                ? html` <div class="text">${prettyBytes(p.size)}</div>`
                 : ""}
             </div>
           </div>

--- a/src/pageentry.ts
+++ b/src/pageentry.ts
@@ -5,6 +5,8 @@ import { property, state } from "lit/decorators.js";
 
 import "keyword-mark-element/lib/keyword-mark.js";
 
+import faFileImage from "@fortawesome/fontawesome-free/svgs/solid/file-image.svg";
+
 import { getPageDateTS, getReplayLink } from "./pageutils";
 
 import { wrapCss } from "./misc";
@@ -92,6 +94,37 @@ class PageEntry extends LitElement {
         margin-bottom: calc(-0.75rem + 2px);
       }
 
+      .thumbnail {
+        background-color: var(--sl-color-neutral-100);
+        border: 1px solid var(--sl-color-neutral-200);
+        border-radius: var(--sl-border-radius-large);
+      }
+
+      .thumbnail-placeholder {
+        position: relative;
+      }
+
+      .thumbnail-placeholder-content {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        overflow: clip;
+      }
+
+      .thumbnail-placeholder-content .icon {
+        margin: var(--sl-spacing-2x-small) 0;
+        color: var(--sl-color-neutral-300);
+      }
+
+      .thumbnail-placeholder-label {
+        font-size: var(--sl-font-size-x-small);
+        color: var(--sl-color-neutral-500);
+        line-height: 1;
+      }
+
       .favicon {
         display: inline-block;
         vertical-align: text-bottom;
@@ -143,12 +176,10 @@ class PageEntry extends LitElement {
 
       .current a {
         background-color: rgb(207, 243, 255);
-        font-style: italic;
         display: block;
       }
 
       .current .curr-page {
-        font-style: italic;
         font-size: 9px;
         color: black;
       }
@@ -163,6 +194,14 @@ class PageEntry extends LitElement {
 
       .col-date {
         font-variant-numeric: tabular-nums;
+      }
+
+      .date-time {
+        font-size: var(--sl-font-size-small);
+      }
+
+      .url {
+        font-size: var(--sl-font-size-small);
       }
     `);
   }
@@ -185,7 +224,7 @@ class PageEntry extends LitElement {
       }
       ${prefix} .is-inline-date {
         display: initial !important;
-        font-style: italic;
+        font-size: var(--sl-font-size-small);
       }
       ${prefix} .media-left {
         padding-left: 0.75rem;
@@ -229,7 +268,7 @@ class PageEntry extends LitElement {
           : ""}
         <div class="column col-date is-2">
           <div>${date ? dateFormatter.format(date) : ""}</div>
-          <div>${date ? timeFormatter.format(date) : ""}</div>
+          <div class="date-time">${date ? timeFormatter.format(date) : ""}</div>
         </div>
         <div class="column">
           <div class="media">
@@ -247,14 +286,15 @@ class PageEntry extends LitElement {
                   )}"
                 >
                   <p class="is-size-6 has-text-weight-bold has-text-link text">
+                    ${this.renderFavicon()}
                     <keyword-mark keywords="${this.query}"
                       >${p.title || p.url}</keyword-mark
                     >
                   </p>
-                  <p class="has-text-dark text">
+                  <p class="url has-text-dark text">
                     <keyword-mark keywords="${this.query}"
                       >${p.url}</keyword-mark
-                    >${this.thumbnailValid ? this.renderFavicon() : ""}
+                    >
                   </p>
                   <p class="has-text-grey-dark text is-inline-date">
                     ${date ? dateTimeFormatter.format(date) : ""}
@@ -301,7 +341,14 @@ class PageEntry extends LitElement {
 
   private renderPageIcon() {
     if (!this.thumbnailValid) {
-      return this.renderFavicon();
+      return html`<div class="thumbnail thumbnail-placeholder image is-16by9">
+        <div class="thumbnail-placeholder-content">
+          <span class="icon is-small">
+            <fa-icon .svg="${faFileImage}" aria-hidden="true"></fa-icon>
+          </span>
+          <span class="thumbnail-placeholder-label">No image</span>
+        </div>
+      </div>`;
     }
     return html`<img
       class="thumbnail"

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -726,6 +726,7 @@ class Pages extends LitElement {
         flex-direction: column;
         background-color: var(--sl-color-neutral-100);
         border-bottom: 1px solid var(--sl-panel-border-color);
+        font-size: var(--sl-font-size-small);
       }
 
       .main-search-bar {
@@ -734,6 +735,10 @@ class Pages extends LitElement {
 
       .sidebar-search-bar {
         padding: var(--sl-spacing-x-small);
+      }
+
+      .search-bar .input {
+        font-size: var(--sl-font-size-small);
       }
 
       .flex-auto {

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -518,7 +518,7 @@ class Pages extends LitElement {
         display: flex;
         flex-direction: column;
         border-right: 1px solid var(--sl-panel-border-color);
-        background-color: var(--sl-color-neutral-100);
+        background-color: var(--sl-color-neutral-50);
         position: relative;
         padding: 0;
       }

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -18,10 +18,10 @@ import prettyBytes from "pretty-bytes";
 
 import { getTS, getPageDateTS } from "./pageutils";
 
-import fasSearch from "@fortawesome/fontawesome-free/svgs/solid/search.svg";
-import fasAngleDown from "@fortawesome/fontawesome-free/svgs/solid/angle-down.svg";
-import faArrowDown from "@fortawesome/fontawesome-free/svgs/solid/arrow-down.svg";
-import fasEdit from "@fortawesome/fontawesome-free/svgs/solid/edit.svg";
+import iconArrowDown from "~icons/arrow-down.svg";
+import iconChevronDown from "~icons/chevron-down.svg";
+import iconPencil from "~icons/pencil.svg";
+import iconSearch from "~icons/search.svg";
 
 import type { Sorter } from "./sorter";
 import type { PageEntry } from "./pageentry";
@@ -691,11 +691,14 @@ class Pages extends LitElement {
       }
 
       .scroller-help-text {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--sl-spacing-2x-small);
         color: var(--sl-color-neutral-500);
       }
 
-      .scroller-help-text .icon {
-        font-size: 10px;
+      .scroller-help-text wr-icon {
+        font-size: var(--sl-font-size-medium);
       }
 
       .page-entry {
@@ -728,13 +731,6 @@ class Pages extends LitElement {
         background-color: var(--sl-color-neutral-100);
         border-bottom: 1px solid var(--sl-panel-border-color);
         font-size: var(--sl-font-size-small);
-      }
-
-      .main-search-bar {
-        padding: var(--sl-spacing-small);
-      }
-
-      .sidebar-search-bar {
         padding: var(--sl-spacing-x-small);
       }
 
@@ -820,11 +816,7 @@ class Pages extends LitElement {
       >
         Pages in ${this.collInfo!.title}
       </div>
-      <div
-        class="search-bar is-marginless ${this.isSidebar
-          ? "sidebar-search-bar"
-          : "main-search-bar"}"
-      >
+      <div class="search-bar is-marginless">
         ${this.isSidebar
           ? html`<h3 class="is-sr-only">Search and Filter Pages</h3>`
           : ""}
@@ -839,8 +831,8 @@ class Pages extends LitElement {
               type="text"
               placeholder="Search by Page URL, Title, or Text"
             />
-            <span class="icon is-left"
-              ><fa-icon .svg="${fasSearch}" aria-hidden="true"></fa-icon
+            <span class="icon is-left is-small"
+              ><wr-icon .svg="${iconSearch}"></wr-icon
             ></span>
           </div>
         </div>
@@ -886,7 +878,7 @@ class Pages extends LitElement {
                       </div>`
                   : html``}`}
           ${this.editable
-            ? html`<fa-icon class="editIcon" .svg="${fasEdit}"></fa-icon>`
+            ? html`<wr-icon class="editIcon" .svg="${iconPencil}"></wr-icon>`
             : html``}
           ${this.editable
             ? html` <div class="index-bar-actions">
@@ -951,7 +943,7 @@ class Pages extends LitElement {
         >
           <span>Download</span>
           <span class="icon is-small">
-            <fa-icon .svg="${fasAngleDown}" aria-hidden="true"></fa-icon>
+            <wr-icon .svg="${iconChevronDown}"></wr-icon>
           </span>
         </button>
       </div>
@@ -1401,9 +1393,7 @@ class Pages extends LitElement {
         ? nothing
         : html`<span class="scroller-help-text">
             Scroll for more
-            <span class="icon is-small">
-              <fa-icon .svg="${faArrowDown}" aria-hidden="true"></fa-icon>
-            </span>
+            <wr-icon .svg="${iconArrowDown}"></wr-icon>
           </span>`} `;
   }
 

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -700,6 +700,7 @@ class Pages extends LitElement {
 
       .page-entry {
         padding-bottom: 1.5rem;
+        margin-right: -1.5rem;
       }
 
       .selected {

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -1169,6 +1169,7 @@ class Pages extends LitElement {
                   ?selected="${selected}"
                   ?isCurrent="${this.isCurrPage(p)}"
                   ?isSidebar="${this.isSidebar}"
+                  useFaviconFallback
                   .page="${p}"
                   pid="${p.id}"
                   @sel-page="${this.onSelectToggle}"

--- a/src/replay.ts
+++ b/src/replay.ts
@@ -9,6 +9,9 @@ import type { ReplayLoadingDetail, TabNavEvent } from "./events";
 import { keyed } from "lit/directives/keyed.js";
 
 /**
+ * @cssPart iframe
+ * @cssPart iframe-container
+ * @cssPart iframe-page-not-found
  * @fires update-title
  * @fires coll-tab-nav
  * @fires update-title
@@ -462,10 +465,13 @@ class Replay extends LitElement {
                   : undefined,
               )}"
             ></a>
-            <div class="iframe-container">
+            <div part="iframe-container" class="iframe-container">
               ${keyed(
                 this.iframeUrlUpdateKey,
                 html`<iframe
+                  part="iframe ${this.replayNotFoundError
+                    ? "iframe-page-not-found"
+                    : ""}"
                   class="iframe-main"
                   name="___wb_replay_top_frame"
                   @message="${this.onReplayMessage}"

--- a/src/shoelace.ts
+++ b/src/shoelace.ts
@@ -1,8 +1,24 @@
+import { registerIconLibrary } from "@shoelace-style/shoelace/dist/utilities/icon-library.js";
+import systemLibrary from "@shoelace-style/shoelace/dist/components/icon/library.system.js";
+
 // Cherry-picked Shoelace components
 import "@shoelace-style/shoelace/dist/components/alert/alert.js";
 import "@shoelace-style/shoelace/dist/components/button/button.js";
 import "@shoelace-style/shoelace/dist/components/copy-button/copy-button.js";
 import "@shoelace-style/shoelace/dist/components/dialog/dialog.js";
+import "@shoelace-style/shoelace/dist/components/divider/divider.js";
 import "@shoelace-style/shoelace/dist/components/dropdown/dropdown.js";
 import "@shoelace-style/shoelace/dist/components/menu/menu.js";
 import "@shoelace-style/shoelace/dist/components/menu-item/menu-item.js";
+import "@shoelace-style/shoelace/dist/components/menu-label/menu-label.js";
+
+// disable system library to prevent loading of unused data: URLs
+// allow only "x-lg" as it is needed for sl-dialog
+registerIconLibrary("system", {
+  resolver: (name) => {
+    if (name === "x-lg") {
+      return systemLibrary.resolver(name);
+    }
+    return "";
+  },
+});

--- a/src/sorter.ts
+++ b/src/sorter.ts
@@ -3,8 +3,8 @@ import { customElement, property } from "lit/decorators.js";
 
 import { wrapCss } from "./misc";
 
-import fasSortDown from "@fortawesome/fontawesome-free/svgs/solid/sort-down.svg";
-import fasSortUp from "@fortawesome/fontawesome-free/svgs/solid/sort-up.svg";
+import iconSortDown from "~icons/sort-down.svg";
+import iconSortUp from "~icons/sort-up.svg";
 
 // ===========================================================================
 @customElement("wr-sorter")
@@ -126,30 +126,36 @@ class Sorter<T = unknown> extends LitElement {
   }
 
   render() {
-    return html`
-    <div class="select is-small">
-      <select id="sort-select" @change=${(e: Event) =>
-        (this.sortKey = (e.currentTarget as HTMLSelectElement).value)}>
-
-      ${this.sortKeys?.map(
-        (sort) => html`
-          <option value="${sort.key}" ?selected="${sort.key === this.sortKey}">
-            Sort By: ${sort.name}
-          </option>
-        `,
-      )}
-      </select>
-    </div>
-    <button @click=${() =>
-      (this.sortDesc = !this.sortDesc)} class="button is-small">
-      <span>Order:</span>
-      <span class="is-sr-only">${
-        this.sortDesc ? "Ascending" : "Descending"
-      }</span>
-      <span class="icon"><fa-icon aria-hidden="true" .svg=${
-        this.sortDesc ? fasSortUp : fasSortDown
-      }></span>
-    </button>`;
+    return html` <div class="select is-small">
+        <select
+          id="sort-select"
+          @change=${(e: Event) =>
+            (this.sortKey = (e.currentTarget as HTMLSelectElement).value)}
+        >
+          ${this.sortKeys?.map(
+            (sort) => html`
+              <option
+                value="${sort.key}"
+                ?selected="${sort.key === this.sortKey}"
+              >
+                Sort By: ${sort.name}
+              </option>
+            `,
+          )}
+        </select>
+      </div>
+      <button
+        @click=${() => (this.sortDesc = !this.sortDesc)}
+        class="button is-small"
+      >
+        <span>Order:</span>
+        <span class="is-sr-only"
+          >${this.sortDesc ? "Ascending" : "Descending"}</span
+        >
+        <span class="icon"
+          ><wr-icon .svg=${this.sortDesc ? iconSortDown : iconSortUp}></wr-icon
+        ></span>
+      </button>`;
   }
 }
 

--- a/src/url-resources.ts
+++ b/src/url-resources.ts
@@ -281,6 +281,7 @@ class URLResources extends LitElement {
         width: 100%;
         background-color: var(--sl-color-neutral-100);
         border-bottom: 1px solid var(--sl-panel-border-color);
+        font-size: var(--sl-font-size-small);
       }
 
       .main-search-bar {
@@ -291,14 +292,24 @@ class URLResources extends LitElement {
         padding: var(--sl-spacing-x-small);
       }
 
+      .search-bar .level-item {
+        gap: var(--sl-spacing-x-small);
+      }
+
+      .search-bar .input,
+      .search-bar .radio {
+        font-size: var(--sl-font-size-small);
+      }
+
       .all-results {
-        margin: 0 0 0 0.5em;
         display: flex;
         flex-direction: column;
         min-height: 0;
+        flex: 1 1 0;
       }
       .main-scroll {
-        flex-grow: 1;
+        flex: 1 1 0;
+        scrollbar-gutter: stable;
       }
       .minihead {
         font-size: 10px;
@@ -307,26 +318,42 @@ class URLResources extends LitElement {
       .columns {
         margin: 0px;
       }
-      thead {
-        margin-bottom: 24px;
-      }
+
       table th:not([align]) {
         text-align: left;
       }
       .result {
-        border-bottom: 1px #dbdbdb solid;
         min-height: fit-content;
+        font-size: var(--sl-font-size-small);
       }
+
+      .result:first-child {
+        margin-top: var(--sl-spacing-small);
+      }
+
+      .result:not(:last-child) {
+        margin-bottom: 0;
+        border-bottom: 1px solid var(--sl-panel-border-color);
+      }
+
       .results-head {
-        border-bottom: 2px #dbdbdb solid;
-        margin-right: 16px;
+        border-bottom: 1px solid var(--sl-panel-border-color);
         min-height: fit-content;
         display: block;
         width: 100%;
+        padding-right: 15px; // For scrollbar gutter
       }
-      .results-head a {
-        color: black;
+
+      .results-head .column {
+        background-color: var(--sl-panel-background-color);
+        position: relative;
+        z-index: 2;
       }
+
+      table .column {
+        padding: var(--sl-spacing-x-small);
+      }
+
       .all-results .column {
         word-break: break-word;
       }
@@ -341,6 +368,17 @@ class URLResources extends LitElement {
       .flex-auto {
         flex: auto;
       }
+
+      .sort-control-label {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--sl-spacing-2x-small);
+        font-size: var(--sl-font-size-small);
+        font-weight: var(--sl-font-weight-semibold);
+        color: var(--sl-color-neutral-600);
+        padding-bottom: 0;
+      }
+
       .asc:after {
         content: "▼";
         font-size: 0.75em;
@@ -349,9 +387,12 @@ class URLResources extends LitElement {
         content: "▲";
         font-size: 0.75em;
       }
+
       .num-results {
-        margin-left: 1em;
-        font-style: italic;
+        font-size: var(--sl-font-size-small);
+        color: var(--sl-color-neutral-500);
+        line-height: 1;
+        margin-left: var(--sl-spacing-small);
       }
     `);
   }
@@ -380,7 +421,7 @@ class URLResources extends LitElement {
       >
         <div class="level-left flex-auto">
           <div class="level-item flex-auto">
-            <span class="is-hidden-mobile">Search:&nbsp;&nbsp;</span>
+            <span class="is-hidden-mobile">Search:</span>
             <div class="select">
               <select @change="${this.onChangeTypeSearch}">
                 ${URLResources.filters.map(
@@ -450,7 +491,9 @@ class URLResources extends LitElement {
               is-pulled-right
               aria-live="polite"
               aria-atomic="true"
-              >${this.filteredResults.length} Result(s)</span
+              >${this.filteredResults.length.toLocaleString()}
+              ${this.filteredResults.length === 1 ? "result" : "results"}
+              shown</span
             >
           </div>
         </div>
@@ -478,7 +521,7 @@ class URLResources extends LitElement {
       </div>
 
       <table class="all-results" aria-labelledby="results-heading num-results">
-        <thead>
+        <thead class="all-results-header">
           <tr class="columns results-head has-text-weight-bold">
             <th scope="col" class="column col-url is-6 is-hidden-mobile">
               <a
@@ -487,7 +530,7 @@ class URLResources extends LitElement {
                 @click="${this.onSort}"
                 @keyup="${clickOnSpacebarPress}"
                 data-key="url"
-                class="${this.sortKey === "url"
+                class="sort-control-label ${this.sortKey === "url"
                   ? this.sortDesc
                     ? "desc"
                     : "asc"
@@ -502,7 +545,7 @@ class URLResources extends LitElement {
                 @click="${this.onSort}"
                 @keyup="${clickOnSpacebarPress}"
                 data-key="ts"
-                class="${this.sortKey === "ts"
+                class="sort-control-label ${this.sortKey === "ts"
                   ? this.sortDesc
                     ? "desc"
                     : "asc"
@@ -517,7 +560,7 @@ class URLResources extends LitElement {
                 @click="${this.onSort}"
                 @keyup="${clickOnSpacebarPress}"
                 data-key="mime"
-                class="${this.sortKey === "mime"
+                class="sort-control-label ${this.sortKey === "mime"
                   ? this.sortDesc
                     ? "desc"
                     : "asc"
@@ -532,7 +575,7 @@ class URLResources extends LitElement {
                 @click="${this.onSort}"
                 @keyup="${clickOnSpacebarPress}"
                 data-key="status"
-                class="${this.sortKey === "status"
+                class="sort-control-label ${this.sortKey === "status"
                   ? this.sortDesc
                     ? "desc"
                     : "asc"
@@ -559,7 +602,6 @@ class URLResources extends LitElement {
                         )}"
                         ><fa-icon
                           size="1.0em"
-                          class="has-text-black"
                           aria-hidden="true"
                           title="Download Resource"
                           .svg="${fasDownload}"

--- a/src/url-resources.ts
+++ b/src/url-resources.ts
@@ -3,8 +3,9 @@ import { wrapCss, clickOnSpacebarPress } from "./misc";
 
 import { getReplayLink, getDownloadLink } from "./pageutils";
 
-import fasSearch from "@fortawesome/fontawesome-free/svgs/solid/search.svg";
 import fasDownload from "@fortawesome/fontawesome-free/svgs/solid/download.svg";
+
+import iconSearch from "~icons/search.svg";
 
 import "keyword-mark-element/lib/keyword-mark.js";
 import { type ItemType } from "./types";
@@ -282,13 +283,6 @@ class URLResources extends LitElement {
         background-color: var(--sl-color-neutral-100);
         border-bottom: 1px solid var(--sl-panel-border-color);
         font-size: var(--sl-font-size-small);
-      }
-
-      .main-search-bar {
-        padding: var(--sl-spacing-small);
-      }
-
-      .sidebar-search-bar {
         padding: var(--sl-spacing-x-small);
       }
 
@@ -414,11 +408,7 @@ class URLResources extends LitElement {
       >
         Search and Filter
       </div>
-      <div
-        class="search-bar level is-marginless ${this.isSidebar
-          ? "sidebar-search-bar"
-          : "main-search-bar"}"
-      >
+      <div class="search-bar level is-marginless">
         <div class="level-left flex-auto">
           <div class="level-item flex-auto">
             <span class="is-hidden-mobile">Search:</span>
@@ -449,8 +439,8 @@ class URLResources extends LitElement {
                   .value="${this.query}"
                   placeholder="Enter URL to Search"
                 />
-                <span class="icon is-left"
-                  ><fa-icon .svg="${fasSearch}"></fa-icon
+                <span class="icon is-left is-small"
+                  ><wr-icon .svg="${iconSearch}"></wr-icon
                 ></span>
               </div>
             </div>

--- a/src/url-resources.ts
+++ b/src/url-resources.ts
@@ -3,8 +3,7 @@ import { wrapCss, clickOnSpacebarPress } from "./misc";
 
 import { getReplayLink, getDownloadLink } from "./pageutils";
 
-import fasDownload from "@fortawesome/fontawesome-free/svgs/solid/download.svg";
-
+import iconDownload from "~icons/download.svg";
 import iconSearch from "~icons/search.svg";
 
 import "keyword-mark-element/lib/keyword-mark.js";
@@ -351,9 +350,19 @@ class URLResources extends LitElement {
       .all-results .column {
         word-break: break-word;
       }
-      .dl-button {
-        padding: 4px;
+
+      tbody .col-url a {
+        word-break: break-all;
       }
+
+      .dl-button {
+        display: inline-block;
+        font-size: 1.125rem;
+        width: 1.5rem;
+        height: 1.5rem;
+        padding: var(--sl-spacing-3x-small);
+      }
+
       div.sort-header {
         padding: 10px;
         margin-bottom: 0px !important;
@@ -543,7 +552,7 @@ class URLResources extends LitElement {
                 >Date</a
               >
             </th>
-            <th scope="col" class="column col-mime is-3 is-hidden-mobile">
+            <th scope="col" class="column col-mime is-2 is-hidden-mobile">
               <a
                 role="button"
                 href="#"
@@ -573,6 +582,9 @@ class URLResources extends LitElement {
                 >Status</a
               >
             </th>
+            <th scope="col" class="column col-actions is-1 is-hidden-mobile">
+              <span class="sr-only">Actions</span>
+            </th>
           </tr>
         </thead>
 
@@ -583,20 +595,6 @@ class URLResources extends LitElement {
                   <tr class="columns result">
                     <td class="column col-url is-6">
                       <p class="minihead is-hidden-tablet">URL</p>
-                      <a
-                        class="dl-button"
-                        href="${getDownloadLink(
-                          this.collInfo!.replayPrefix,
-                          result.url,
-                          result.ts,
-                        )}"
-                        ><fa-icon
-                          size="1.0em"
-                          aria-hidden="true"
-                          title="Download Resource"
-                          .svg="${fasDownload}"
-                        ></fa-icon>
-                      </a>
                       <a
                         @click="${this.onReplay}"
                         data-url="${result.url}"
@@ -616,13 +614,28 @@ class URLResources extends LitElement {
                       <p class="minihead is-hidden-tablet">Date</p>
                       ${dateTimeFormatter.format(new Date(result.date))}
                     </td>
-                    <td class="column col-mime is-3">
+                    <td class="column col-mime is-2">
                       <p class="minihead is-hidden-tablet">Media Type</p>
                       ${result.mime}
                     </td>
                     <td class="column col-status is-1">
                       <p class="minihead is-hidden-tablet">Status</p>
                       ${result.status}
+                    </td>
+                    <td class="column col-actions is-1">
+                      <a
+                        class="dl-button"
+                        href="${getDownloadLink(
+                          this.collInfo!.replayPrefix,
+                          result.url,
+                          result.ts,
+                        )}"
+                        download
+                        ><wr-icon
+                          title="Download Resource"
+                          .svg="${iconDownload}"
+                        ></wr-icon>
+                      </a>
                     </td>
                   </tr>
                 `,


### PR DESCRIPTION
Resolves https://github.com/webrecorder/replayweb.page/issues/237
Related to https://github.com/webrecorder/browsertrix/issues/3337

## Changes

- Updates general styles and icons throughout to match Browsertrix styles
- Allows deep customization of components with `part` and `exportparts`

## Screenshots

| Before | After |
| --- | --- |
| <img width="1412" height="866" alt="Screenshot 2026-06-04 at 10 16 53 PM" src="https://github.com/user-attachments/assets/fd8b5b6c-50a2-486a-bb82-76f0bd640ae8" /> | <img width="1412" height="866" alt="Screenshot 2026-06-04 at 10 10 12 PM" src="https://github.com/user-attachments/assets/eab99f14-9856-422b-a595-7971847613a9" /> |
| <img width="1412" height="866" alt="Screenshot 2026-06-04 at 10 16 55 PM" src="https://github.com/user-attachments/assets/074b48cf-7c4b-4cf6-85c4-35f094a9c28b" /> | <img width="1412" height="866" alt="Screenshot 2026-06-04 at 10 10 14 PM" src="https://github.com/user-attachments/assets/590352f7-84d6-4b0f-b54f-cf315639f8af" /> |
| <img width="1412" height="866" alt="Screenshot 2026-06-04 at 10 16 38 PM" src="https://github.com/user-attachments/assets/55df4440-7892-47d1-b435-9c796154a490" /> | <img width="1412" height="866" alt="Screenshot 2026-06-04 at 10 15 29 PM" src="https://github.com/user-attachments/assets/5093a1cf-cff8-405c-8c58-39cea744f6c7" /> |
|  <img width="1412" height="866" alt="Screenshot 2026-06-04 at 10 16 44 PM" src="https://github.com/user-attachments/assets/ece07421-b68e-4034-ba69-923ee7e12c20" /> |<img width="1412" height="866" alt="Screenshot 2026-06-04 at 10 10 26 PM" src="https://github.com/user-attachments/assets/74161690-05d9-40db-a5cb-ddfe23c3a7ba" /> |

### Customization example using `part`

<img width="1260" height="615" alt="Screenshot 2026-06-05 at 10 23 44 AM" src="https://github.com/user-attachments/assets/d145e20f-2e31-48f7-873b-eed5929cfebb" />
