### PR TITLE
feat: Inline Shoelace icons + update location bar icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "lint-staged": "^14.0.0",
     "mini-css-extract-plugin": "^2.3.0",
     "prettier": "^3.0.1",
-    "raw-loader": "^4.0.2",
     "sass-embedded": "^1.70.0",
     "sass-loader": "^13.3.2",
     "serve": "^14.2.4",

--- a/src/components/icon.ts
+++ b/src/components/icon.ts
@@ -1,0 +1,38 @@
+import { css, LitElement } from "lit";
+import { unsafeSVG } from "lit/directives/unsafe-svg.js";
+import { customElement, property } from "lit/decorators.js";
+
+/**
+ * Based on `<sl-icon>` but uses inline SVG.
+ */
+@customElement("wr-icon")
+export class Icon extends LitElement {
+  static styles = css`
+    :host {
+      display: inline-block;
+      width: 1em;
+      height: 1em;
+      box-sizing: content-box !important;
+    }
+
+    svg {
+      display: block;
+      height: 100%;
+      width: 100%;
+    }
+  `;
+
+  /**
+   * Raw SVG string
+   */
+  @property({ type: String })
+  svg?: string;
+
+  render() {
+    if (!this.svg) {
+      return;
+    }
+
+    return unsafeSVG(this.svg);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { URLResources } from "./url-resources";
 import { Embed } from "./embed";
 import "./coll-description";
 import "./shoelace";
+import "./components/icon";
 
 import rwpIcon from "~assets/icons/replaywebpage.svg";
 import rwpLogoAnimated from "~assets/brand/replaywebpage-icon-color-animated.svg";

--- a/src/item.ts
+++ b/src/item.ts
@@ -30,23 +30,22 @@ import fasBook from "@fortawesome/fontawesome-free/svgs/solid/book.svg";
 import fasDownload from "@fortawesome/fontawesome-free/svgs/solid/download.svg";
 import fasFileDownload from "@fortawesome/fontawesome-free/svgs/regular/arrow-alt-circle-down.svg";
 
-import farListAlt from "@fortawesome/fontawesome-free/svgs/regular/list-alt.svg";
 import farResources from "@fortawesome/fontawesome-free/svgs/solid/puzzle-piece.svg";
 import farPages from "@fortawesome/fontawesome-free/svgs/regular/file-image.svg";
 import fasInfoIcon from "@fortawesome/fontawesome-free/svgs/solid/info-circle.svg";
 import fasSync from "@fortawesome/fontawesome-free/svgs/solid/sync-alt.svg";
 
-import fasRefresh from "@fortawesome/fontawesome-free/svgs/solid/redo-alt.svg";
-import fasFullscreen from "@fortawesome/fontawesome-free/svgs/solid/desktop.svg";
-import fasUnfullscreen from "@fortawesome/fontawesome-free/svgs/solid/compress-arrows-alt.svg";
-
-import fasLeft from "@fortawesome/fontawesome-free/svgs/solid/arrow-left.svg";
-import fasRight from "@fortawesome/fontawesome-free/svgs/solid/arrow-right.svg";
-import fasMenuV from "@fortawesome/fontawesome-free/svgs/solid/ellipsis-v.svg";
-
 import fasAngleLeft from "@fortawesome/fontawesome-free/svgs/solid/angle-left.svg";
 import fasAngleRight from "@fortawesome/fontawesome-free/svgs/solid/angle-right.svg";
 import fasCaretDown from "@fortawesome/fontawesome-free/svgs/solid/caret-down.svg";
+
+import iconArrowClockwise from "~icons/arrow-clockwise.svg";
+import iconArrowLeft from "~icons/arrow-left.svg";
+import iconArrowRight from "~icons/arrow-right.svg";
+import iconArrowsFullscreen from "~icons/arrows-fullscreen.svg";
+import iconExitFullscreen from "~icons/fullscreen-exit.svg";
+import iconLayoutSidebar from "~icons/layout-sidebar.svg";
+import iconThreeDotsVertical from "~icons/three-dots-vertical.svg";
 
 import { RWPEmbedReceipt } from "./embed-receipt";
 import Split from "split.js";
@@ -731,6 +730,10 @@ class Item extends LitElement {
         background-color: white;
       }
 
+      .replay-bar .icon {
+        font-size: 1.125rem;
+      }
+
       input#url {
         border-radius: 4px;
       }
@@ -1177,12 +1180,11 @@ class Item extends LitElement {
             aria-controls="contents"
           >
             <span class="icon is-small">
-              <fa-icon
-                size="1.0em"
+              <wr-icon
                 class="has-text-grey"
                 aria-hidden="true"
-                .svg="${farListAlt}"
-              ></fa-icon>
+                .svg="${iconLayoutSidebar}"
+              ></wr-icon>
             </span>
           </a>`
         : ""}
@@ -1196,12 +1198,11 @@ class Item extends LitElement {
         aria-label="Back"
       >
         <span class="icon is-small">
-          <fa-icon
-            size="1.0em"
+          <wr-icon
             class="has-text-grey"
             aria-hidden="true"
-            .svg="${fasLeft}"
-          ></fa-icon>
+            .svg="${iconArrowLeft}"
+          ></wr-icon>
         </span>
       </a>
       <a
@@ -1214,12 +1215,11 @@ class Item extends LitElement {
         aria-label="Forward"
       >
         <span class="icon is-small">
-          <fa-icon
-            size="1.0em"
+          <wr-icon
             class="has-text-grey"
             aria-hidden="true"
-            .svg="${fasRight}"
-          ></fa-icon>
+            .svg="${iconArrowRight}"
+          ></wr-icon>
         </span>
       </a>
       <a
@@ -1237,12 +1237,11 @@ class Item extends LitElement {
         <span class="icon is-small">
           ${!this.isLoading
             ? html`
-                <fa-icon
-                  size="1.0em"
+                <wr-icon
                   class="has-text-grey"
                   aria-hidden="true"
-                  .svg="${fasRefresh}"
-                ></fa-icon>
+                  .svg="${iconArrowClockwise}"
+                ></wr-icon>
               `
             : ""}
         </span>
@@ -1337,12 +1336,13 @@ class Item extends LitElement {
         aria-label="${this.isFullscreen ? "Exit Fullscreen" : "Fullscreen"}"
       >
         <span class="icon is-small">
-          <fa-icon
-            size="1.0em"
+          <wr-icon
             class="has-text-grey"
             aria-hidden="true"
-            .svg="${this.isFullscreen ? fasUnfullscreen : fasFullscreen}"
-          ></fa-icon>
+            .svg="${this.isFullscreen
+              ? iconExitFullscreen
+              : iconArrowsFullscreen}"
+          ></wr-icon>
         </span>
       </a>
       <div class="dropdown-trigger">
@@ -1355,12 +1355,11 @@ class Item extends LitElement {
           aria-label="more replay controls"
         >
           <span class="icon is-small">
-            <fa-icon
-              size="1.0em"
+            <wr-icon
               class="has-text-grey"
               aria-hidden="true"
-              .svg="${fasMenuV}"
-            ></fa-icon>
+              .svg="${iconThreeDotsVertical}"
+            ></wr-icon>
           </span>
         </button>
       </div>
@@ -1374,12 +1373,13 @@ class Item extends LitElement {
             @keyup="${clickOnSpacebarPress}"
           >
             <span class="icon is-small">
-              <fa-icon
-                size="1.0em"
+              <wr-icon
                 class="has-text-grey"
                 aria-hidden="true"
-                .svg="${this.isFullscreen ? fasUnfullscreen : fasFullscreen}"
-              ></fa-icon>
+                .svg="${this.isFullscreen
+                  ? iconExitFullscreen
+                  : iconArrowsFullscreen}"
+              ></wr-icon>
             </span>
             <span>Full Screen</span>
           </a>
@@ -1394,12 +1394,11 @@ class Item extends LitElement {
                 @keyup="${clickOnSpacebarPress}"
               >
                 <span class="icon is-small">
-                  <fa-icon
-                    size="1.0em"
+                  <wr-icon
                     class="has-text-grey"
                     aria-hidden="true"
-                    .svg="${farListAlt}"
-                  ></fa-icon>
+                    .svg="${iconLayoutSidebar}"
+                  ></wr-icon>
                 </span>
                 <span>Browse Contents</span>
               </a>`

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -57,6 +57,9 @@ export function updateFaviconLinks(data: FavIconEventDetail) {
 }
 
 // ===========================================================================
+/**
+ * @deprecated Use `<wr-icon>`
+ */
 class FaIcon extends LitElement {
   constructor() {
     super();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,11 @@
   "compilerOptions": {
     "outDir": "./dist/",
     "module": "esnext",
-    "lib": ["esnext", "dom", "dom.iterable"],
+    "lib": [
+      "esnext",
+      "dom",
+      "dom.iterable"
+    ],
     "target": "es6",
     "moduleResolution": "Bundler",
     "allowJs": true,
@@ -29,9 +33,21 @@
     ],
     "incremental": true,
     "paths": {
-      "flexsearch": ["./node_modules/@types/flexsearch"],
-      "~assets/*": ["./src/assets/*"]
+      "flexsearch": [
+        "./node_modules/@types/flexsearch"
+      ],
+      "~assets/*": [
+        "./src/assets/*"
+      ],
+      "~icons/*": [
+        "./node_modules/@shoelace-style/shoelace/dist/assets/icons/*",
+        "./node_modules/@fortawesome/fontawesome-free/svgs/*",
+      ],
     }
   },
-  "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.d.ts"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.js",
+    "src/**/*.d.ts"
+  ]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,6 +51,22 @@ const tsConfig = {
   },
 };
 
+/** @type {import("webpack").Configuration.module.rules} */
+const commonModuleRules = [
+  {
+    test: /\.svg$/,
+    type: "asset/source",
+  },
+  {
+    test: /main.scss$/,
+    use: ["css-loader", "sass-loader"],
+  },
+  {
+    test: /wombat.js|wombatWorkers.js|index.html$/i,
+    type: "asset/source",
+  },
+];
+
 const electronMainConfig = (/*env, argv*/) => {
   /** @type {import('webpack').Configuration} */
   const config = {
@@ -165,20 +181,7 @@ const libConfig = (env, argv) => {
     ],
 
     module: {
-      rules: [
-        {
-          test: /\.svg$/,
-          use: ["raw-loader"],
-        },
-        {
-          test: /main.scss$/,
-          use: ["css-loader", "sass-loader"],
-        },
-        {
-          test: /wombat.js|wombatWorkers.js|index.html$/i,
-          use: ["raw-loader"],
-        },
-      ],
+      rules: [...commonModuleRules],
     },
   };
   return merge(tsConfig, config);
@@ -258,20 +261,7 @@ const browserConfig = (/*env, argv*/) => {
     ],
 
     module: {
-      rules: [
-        {
-          test: /\.svg$/,
-          use: ["raw-loader"],
-        },
-        {
-          test: /main.scss$/,
-          use: ["css-loader", "sass-loader"],
-        },
-        {
-          test: /wombat.js|wombatWorkers.js|index.html$/i,
-          use: ["raw-loader"],
-        },
-      ],
+      rules: [...commonModuleRules],
     },
   };
   return merge(tsConfig, config);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1425,11 +1425,6 @@ batch@0.6.1:
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
   integrity sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=
 
-big.js@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
-  integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
-
 binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
@@ -2377,11 +2372,6 @@ emoji-regex@^9.2.2:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
-
-emojis-list@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
-  integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -3784,13 +3774,6 @@ json-stringify-safe@^5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json5@^2.1.2:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
-  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
-  dependencies:
-    minimist "^1.2.5"
-
 json5@^2.2.2, json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
@@ -3932,15 +3915,6 @@ loader-runner@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.3.1.tgz#6c76ed29b0ccce9af379208299f07f876de737e3"
   integrity sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==
-
-loader-utils@^2.0.0:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
-  integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
-  dependencies:
-    big.js "^5.2.2"
-    emojis-list "^3.0.0"
-    json5 "^2.1.2"
 
 locate-path@^5.0.0:
   version "5.0.0"
@@ -5146,14 +5120,6 @@ raw-body@2.5.2:
     http-errors "2.0.0"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
-
-raw-loader@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-4.0.2.tgz#1aac6b7d1ad1501e66efdac1522c73e59a584eb6"
-  integrity sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
 
 rc@^1.0.1, rc@^1.1.6:
   version "1.2.8"


### PR DESCRIPTION
Resolves https://github.com/webrecorder/replayweb.page/issues/470
Partially addresses https://github.com/webrecorder/replayweb.page/issues/237

## Changes

- Enables importing Shoelace (ie Bootstrap) icons as inline SVG
- Updates location bar buttons to use Bootstrap icons
- Replaces deprecated raw-loader with Webpack-native asset rule.

## Screenshots

### Before
<img width="1037" height="47" alt="Screenshot 2026-06-05 at 12 35 47 PM" src="https://github.com/user-attachments/assets/28c5a780-687b-493f-a25b-f234800c1492" />

### After
<img width="1034" height="47" alt="Screenshot 2026-06-05 at 12 36 02 PM" src="https://github.com/user-attachments/assets/6a53f946-7ad0-46e0-814b-8d7912a172ae" />
