### PR TITLE
feat: Allow hiding metadata in embed

### DIFF
--- a/src/appmain.ts
+++ b/src/appmain.ts
@@ -665,6 +665,10 @@ export class ReplayWebApp extends LitElement {
       if (this.pageParams.has("noMediaDownload")) {
         this.embedOpts = { ...this.embedOpts, noMediaDownloadUI: true };
       }
+
+      if (this.pageParams.has("hideCollectionMetadata")) {
+        this.embedOpts = { ...this.embedOpts, hideCollectionMetadata: true };
+      }
     }
 
     if (this.pageParams.get("config")) {

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -68,6 +68,7 @@ class Embed extends LitElement {
   @property({ type: Boolean }) hideOffscreen: boolean | undefined;
 
   @property({ type: Boolean }) noMediaDownload = false;
+  @property({ type: Boolean }) hideCollectionMetadata = false;
 
   @property({ type: Boolean }) useAdblock = false;
   @property({ type: String }) adblockRulesUrl = DEFAULT_ADBLOCK_FILE;
@@ -326,6 +327,7 @@ class Embed extends LitElement {
         ruffle?: "1";
         adblockUrl?: string;
         noMediaDownload?: string;
+        hideCollectionMetadata?: string;
       } = {
         source,
         customColl: this.coll,
@@ -369,6 +371,10 @@ class Embed extends LitElement {
 
       if (this.noMediaDownload) {
         params.noMediaDownload = "1";
+      }
+
+      if (this.hideCollectionMetadata) {
+        params.hideCollectionMetadata = "1";
       }
 
       this.paramString = new URLSearchParams(

--- a/src/item.ts
+++ b/src/item.ts
@@ -83,6 +83,7 @@ export type LoadInfo = {
 
 export type EmbedOpts = {
   noMediaDownloadUI?: boolean;
+  hideCollectionMetadata?: boolean;
 };
 
 export enum EmbedReplayDataView {
@@ -1730,6 +1731,7 @@ class Item extends LitElement {
             .url="${this.tabData.url || ""}"
             .ts="${this.tabData.ts || ""}"
             ?showAllPages=${this.showAllPages}
+            ?hideCollectionMetadata=${this.embedOpts.hideCollectionMetadata}
             @coll-tab-nav="${this.onItemTabNav}"
             id="pages"
             @coll-update="${this.onItemUpdate}"

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -608,12 +608,7 @@ class Pages extends LitElement {
         align-items: center;
         gap: var(--sl-spacing-x-small);
         line-height: 1;
-      }
-
-      .index-bar .seed-pages-filter {
-        font-weight: var(--sl-font-weight-semibold);
-        margin-bottom: var(--sl-spacing-medium);
-        padding: var(--sl-spacing-small);
+        padding-inline-end: var(--sl-spacing-x-small);
       }
 
       .sorter {
@@ -623,11 +618,6 @@ class Pages extends LitElement {
 
       .sorter wr-sorter {
         flex-grow: 1;
-      }
-
-      .sorter .seed-pages-filter {
-        flex-shrink: 0;
-        font-size: var(--sl-font-size-x-small);
       }
 
       .sort-control-label {
@@ -683,6 +673,11 @@ class Pages extends LitElement {
         display: flex !important;
       }
 
+      :host(.sidebar) .search-bar {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
       .scroller {
         overflow-y: auto;
         overflow-x: hidden;
@@ -730,7 +725,8 @@ class Pages extends LitElement {
       .search-bar {
         width: auto;
         display: flex;
-        flex-direction: column;
+        align-items: center;
+        gap: var(--sl-spacing-small);
         background-color: var(--sl-color-neutral-100);
         border-bottom: 1px solid var(--sl-panel-border-color);
         font-size: var(--sl-font-size-small);
@@ -810,6 +806,12 @@ class Pages extends LitElement {
 
   render() {
     const currList = this.currList;
+    const collList = this.collInfo?.lists.length;
+    const hideSideCol =
+      this.hideCollectionMetadata &&
+      !this.editable &&
+      !this.editing &&
+      !collList;
 
     return html`
       <div
@@ -823,7 +825,7 @@ class Pages extends LitElement {
         ${this.isSidebar
           ? html`<h3 class="is-sr-only">Search and Filter Pages</h3>`
           : ""}
-        <div class="field flex-auto">
+        <div class="flex-auto">
           <div
             class="control has-icons-left ${this.loading ? "is-loading" : ""}"
           >
@@ -839,14 +841,16 @@ class Pages extends LitElement {
             ></span>
           </div>
         </div>
+        ${this.renderSeedPagesFilter()}
       </div>
       <div class="main columns">
         <div
           class="column index-bar is-one-fifth ${this.isSidebar
             ? "is-hidden-mobile"
+            : hideSideCol
+            ? "is-hidden"
             : ""}"
         >
-          ${this.renderSeedPagesFilter()}
           ${this.editable && this.editing
             ? html`
                 <form @submit="${this.onUpdateTitle}">
@@ -890,7 +894,7 @@ class Pages extends LitElement {
                 ${this.renderDownloadMenu()}
               </div>`
             : ""}
-          ${this.collInfo!.lists.length
+          ${collList
             ? html`
                 <p id="filter-label" class="menu-label">Filter By List:</p>
                 <div class="index-bar-menu menu">
@@ -1082,8 +1086,6 @@ class Pages extends LitElement {
           class="${this.filteredPages.length ? "" : "is-hidden"}"
         >
         </wr-sorter>
-
-        ${this.renderSeedPagesFilter()}
       </div>
     `;
   }

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -109,6 +109,9 @@ class Pages extends LitElement {
   collInfo: ItemType | Record<string, never> | null = null;
 
   @property({ type: Boolean })
+  hideCollectionMetadata = false;
+
+  @property({ type: Boolean })
   allSelected = false;
 
   @property({ type: String })
@@ -855,7 +858,9 @@ class Pages extends LitElement {
                   />
                 </form>
               `
-            : html` <div class="index-bar-label is-hidden-mobile">
+            : this.hideCollectionMetadata
+            ? nothing
+            : html`<div class="index-bar-label is-hidden-mobile">
                   Collection Name
                 </div>
                 <div


### PR DESCRIPTION

Related https://github.com/webrecorder/browsertrix/issues/3376

## Changes

- Allows hiding collection metadata in embed.
- Moves non-seed toggle next to search bar to match resources controls and enable hiding entire column when metadata is hidden.

## Screenshots

### Pages view

<img width="1063" height="585" alt="Screenshot 2026-06-12 at 2 39 58 PM" src="https://github.com/user-attachments/assets/9d018f04-19a4-4501-82ce-4ae9a4127a22" />

### Sidebar view

<img width="448" height="655" alt="Screenshot 2026-06-12 at 2 40 20 PM" src="https://github.com/user-attachments/assets/ca65a59d-4b9c-441c-86a0-27490c8f85ea" />

### Embed example

<img width="1254" height="733" alt="Screenshot 2026-06-12 at 2 42 59 PM" src="https://github.com/user-attachments/assets/833c0783-cfd8-4c77-b826-f15fbe3439e0" />
