### PR TITLE
ci: Tag prerelease

### DIFF
--- a/.github/workflows/npm-release.yaml
+++ b/.github/workflows/npm-release.yaml
@@ -24,7 +24,14 @@ jobs:
       - name: Yarn Run Build
         run: yarn run build
 
+      - name: Npm Publish Pre-Release!
+        if: github.event.release.prerelease
+        run: npm publish --tag next
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Npm Publish!
+        if: ${{ !github.event.release.prerelease }}
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Tags prerelease when running `npm publish` in GitHub Action to fix errors like https://github.com/webrecorder/replayweb.page/actions/runs/28827786541/job/85494783870