### PR TITLE
fix: Update non-seed pages toggle

### DIFF
--- a/src/pages.ts
+++ b/src/pages.ts
@@ -699,10 +699,6 @@ class Pages extends LitElement {
         color: var(--sl-color-neutral-500);
       }
 
-      .scroller-help-text wr-icon {
-        font-size: var(--sl-font-size-medium);
-      }
-
       .page-entry {
         padding-bottom: 1.5rem;
         margin-right: -1.5rem;
@@ -1386,9 +1382,7 @@ class Pages extends LitElement {
   }
 
   renderPaginationResults() {
-    const collTotal = this.dynamicPagesQuery && this.collInfo?.pageCount;
-    const filteredTotal = this.filteredPagesTotal;
-    const total = collTotal || filteredTotal;
+    const total = this.filteredPagesTotal;
     const shown = this.sortedPages.length;
 
     const totalStr = `${total.toLocaleString()} ${

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -607,8 +607,12 @@ class Pages extends LitElement {
         display: flex;
         align-items: center;
         gap: var(--sl-spacing-x-small);
-        line-height: 1;
+        line-height: 1.5;
         padding-inline-end: var(--sl-spacing-x-small);
+      }
+
+      .seed-pages-filter .checkbox span {
+        margin-top: -0.0875rem;
       }
 
       .sorter {
@@ -1415,7 +1419,7 @@ class Pages extends LitElement {
           type="checkbox"
           .checked="${this.showAllPages}"
         />
-        Include Non-Seed Pages
+        <span>Include Non-Seed Pages</span>
       </label>
     </div>`;
   }

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -241,7 +241,7 @@ class Pages extends LitElement {
         (inx: Id) => this.textPages![inx as number],
       );
     } else if (this.showAllPages && this.hasExtraPages) {
-      this.filteredPages = [...this.textPages!];
+      this.filteredPages = [...this.textPages!, ...this.collInfo!.pages];
     } else if (!this.dynamicPagesQuery) {
       this.filteredPages = [...this.collInfo!.pages];
     }
@@ -1415,7 +1415,7 @@ class Pages extends LitElement {
           type="checkbox"
           .checked="${this.showAllPages}"
         />
-        Show Non-Seed Pages
+        Include Non-Seed Pages
       </label>
     </div>`;
   }

--- a/src/url-resources.ts
+++ b/src/url-resources.ts
@@ -268,6 +268,10 @@ class URLResources extends LitElement {
         display: block !important;
       }
 
+      :host(.sidebar) .level-left {
+        margin-bottom: var(--sl-spacing-x-small);
+      }
+
       :host(.sidebar) .columns {
         display: flex !important;
         flex-direction: column;
@@ -278,6 +282,7 @@ class URLResources extends LitElement {
       }
 
       .search-bar {
+        gap: var(--sl-spacing-small);
         width: 100%;
         background-color: var(--sl-color-neutral-100);
         border-bottom: 1px solid var(--sl-panel-border-color);
@@ -456,7 +461,7 @@ class URLResources extends LitElement {
           </div>
         </div>
         <div class="control level-right">
-          <div style="margin-left: 1em" class="control">
+          <div class="control">
             <label class="radio has-text-left"
               ><input
                 type="radio"


### PR DESCRIPTION
The "Show Non-Seed Pages" toggle doesn't work as expected since it excludes seed pages rather than being an inclusive show-all. This change updates the toggle label to be clearer and updates the filter to show all pages. Also includes minor fixes to layout when the search bar is in the side bar.