### PR TITLE
ruffle: forward useRuffle to the sw.js registration in embed mode

### DIFF
--- a/src/embed.ts
+++ b/src/embed.ts
@@ -112,7 +112,13 @@ class Embed extends LitElement {
       return;
     }
 
-    const name = this.swName + "?serveIndex=1";
+    const swParams = new URLSearchParams();
+    swParams.set("serveIndex", "1");
+    if (this.useRuffle) {
+      swParams.set("injectScripts", "ruffle/ruffle.js");
+      swParams.set("allowProxyPaths", "ruffle/");
+    }
+    const name = this.swName + "?" + swParams.toString();
     const appName = this.appName;
     const scope = this.replaybase;
     const requireSubdomainIframe = this.requireSubdomainIframe;


### PR DESCRIPTION
#### Problem
I am experiencing an issue where `useRuffle` has no effect in embed mode. `<replay-web-page useruffle>` correctly sets `ruffle=1` on the iframe URL, but the service worker registration the embed performs is hardcoded:

  ```ts
  // src/embed.ts, doRegister()
  const name = this.swName + "?serveIndex=1";
  ```

Ruffle is enabled by `injectScripts=ruffle/ruffle.js` and `allowProxyPaths=ruffle/`, which the wabac SW reads only from its own registration query. `appmain.ts` sets them but the embed never does, so the controlling SW is always the ruffle-less one and Flash content renders as a blank box.

Present in 2.4.6 and 2.5.0-rc.2.

#### Why `appmain` doesn't cover this

The iframe's `replay-app-main` does get `useRuffle === true`, but it never registers:

  - When the SW-served index's `./ui.js` doesn't resolve (the CDN case, and also the first self-hosting layout in the embedding docs, where ui.js sits next to the HTML and sw.js under replay/) `embed.ts` injects `ui.js` into the iframe from its `onLoad` handler.
  - `register-service-worker` gates registration on a `window.load` listener attached at module evaluation (`src/index.js:26,43`). Injected after `load` has already fired, that listener never runs and `navigator.serviceWorker.register()` is never called.

When `ui.js` *is* co-located and the index path works, both frames register but the parent's `load` fires only after its subresources including the iframe, so the embed's ruffle-less registration runs last. Either way, it appears the embed's registration is the one that ends up controlling, so that's where this PR applies the fix.

#### Testing

Built and self-hosted the patched `ui.js`, embedding a WACZ containing Flash with `useruffle` set:

- Active SW is `sw.js?serveIndex=1&injectScripts=ruffle%2Fruffle.js&allowProxyPaths=ruffle%2F`
- `ruffle.js`, the core chunk, and a `*.wasm` core are all fetched
- The `.swf` files load and a `<ruffle-embed>` element renders the content

#### Note
Wanted to note that I used claude code to aid in some of the investigation with this fix. I don't have full context for the interaction between appmain/embed registrations and the init lifecycle. Is `embed.ts` intended to be sole register point in embed mode?