### PR TITLE
ci: make playwright tests more stable with additional settings

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -37,4 +37,15 @@ export default defineConfig({
       reuseExistingServer: !process.env.CI,
     },
   ],
+
+  timeout: 60000, 
+  expect: { timeout: 10000 },
+
+  workers: process.env.CI ? 2 : undefined,
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
 });

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -38,14 +38,14 @@ export default defineConfig({
     },
   ],
 
-  timeout: 60000, 
+  timeout: 60000,
   expect: { timeout: 10000 },
 
   workers: process.env.CI ? 2 : undefined,
   retries: process.env.CI ? 2 : 0,
   use: {
-    trace: 'retain-on-failure',
-    screenshot: 'only-on-failure',
-    video: 'retain-on-failure',
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
   },
 });

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -2,7 +2,18 @@
 import { defineConfig, devices } from "@playwright/test";
 export default defineConfig({
   reporter: process.env.CI ? "github" : "list",
-  expect: { timeout: 30_000 },
+
+  timeout: 60_000,
+  expect: { timeout: 60_000 },
+
+  workers: process.env.CI ? 2 : undefined,
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+
   projects: [
     {
       name: "chrome",
@@ -36,16 +47,5 @@ export default defineConfig({
       timeout: 120 * 1000,
       reuseExistingServer: !process.env.CI,
     },
-  ],
-
-  timeout: 60000,
-  expect: { timeout: 10000 },
-
-  workers: process.env.CI ? 2 : undefined,
-  retries: process.env.CI ? 2 : 0,
-  use: {
-    trace: "retain-on-failure",
-    screenshot: "only-on-failure",
-    video: "retain-on-failure",
-  },
+  ]
 });


### PR DESCRIPTION
attempt to make playwright more stable on ci: reduce number of workers, increase retries and timeouts 